### PR TITLE
Automatische Versionierung mit buildSrc-Task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,20 @@
 # https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#name
 name: build
 
-# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
-on: [push]
+# https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#on
+on: 
+  # run on push to the default branch and tags
+  push:
+    branches:
+      - 'master'
+      - 'main'
+    tags:
+      - '[0-9]+.[0-9]+'
+  # run on pull requests
+  pull_request:
+    branches:
+      - 'master'
+      - 'main'
 
 # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobs
 jobs:
@@ -10,48 +22,48 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    # https://github.com/actions/checkout
-    - uses: actions/checkout@v4
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    # https://github.com/actions/setup-java
-    - uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '21'
-        cache: 'gradle'
-    
-    # https://github.com/gradle/actions
-    - uses: gradle/actions/setup-gradle@v4
-      with:
-        gradle-version: "8.14"
+      # https://github.com/actions/setup-java
+      - uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+          cache: "gradle"
 
-    # https://github.com/gradle/gradle
-    - name: Build Java
-      run: |
-        gradle versionCheck
-        gradle clean eclipse
-        gradle spotlessCheck
-        gradle build --parallel
-        gradle jacocoTestReport
+      # https://github.com/gradle/actions
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.14"
 
-    # https://github.com/actions/setup-node
-    - uses: actions/setup-node@v4
-      with:
-        node-version: '22'
-    
-    - name: Build Node
-      run: |
-        for dir in app/*
-        do
-          if [ -f "$dir/package.json" ]
-          then
-            (cd $dir && npm install && npm run prettierCheck && npm run build)
-          fi
-        done
+      - name: Build Java
+        run: |
+          gradle versionCheck
+          gradle spotlessCheck
+          gradle build --parallel
+          gradle jacocoTestReport
 
-    # https://github.com/peaceiris/actions-gh-pages
-    - name: Update pages
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir:  pages
+      # https://github.com/actions/setup-node
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Build Node
+        run: |
+          for dir in app/*
+          do
+            if [ -f "$dir/package.json" ]
+            then
+              (cd $dir && npm install && npm run prettierCheck && npm run build)
+            fi
+          done
+
+      # https://github.com/peaceiris/actions-gh-pages
+      - name: Update pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: pages

--- a/app/client/build.gradle
+++ b/app/client/build.gradle
@@ -75,11 +75,8 @@ tasks.register('dockerRun') {
     }
 }
 
-tasks.register('versionCheck') {
+tasks.register('versionCheck', VersionCheckTask.class)  {
     build.dependsOn it
-    assert new File("${projectDir}/package.json")
-            .text
-            .contains('"version": "' + VERSION + '"')
 }
 
 tasks.register('prettierCheck', NpmTask) {

--- a/app/client/src/main/svelte/AppHome.svelte
+++ b/app/client/src/main/svelte/AppHome.svelte
@@ -64,4 +64,12 @@
       </a>
     </div>
   </fieldset>
+  <fieldset class="p-4 border-2 space-y-2">
+    <legend class="text-xs">API-Graphiql</legend>
+    <div class="text-2xl">
+      <a class="underline text-blue-600" href={apiGraphiql} target="_blank"
+        >{apiGraphiql}</a
+      >
+    </div>
+  </fieldset>
 </div>

--- a/app/client/src/main/svelte/AppHome.svelte
+++ b/app/client/src/main/svelte/AppHome.svelte
@@ -64,12 +64,4 @@
       </a>
     </div>
   </fieldset>
-  <fieldset class="p-4 border-2 space-y-2">
-    <legend class="text-xs">API-Graphiql</legend>
-    <div class="text-2xl">
-      <a class="underline text-blue-600" href={apiGraphiql} target="_blank"
-        >{apiGraphiql}</a
-      >
-    </div>
-  </fieldset>
 </div>

--- a/app/deploy/Chart.yaml
+++ b/app/deploy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: deploy
+type: application
+description: A self contained system with spring boot and svelte
+version: 0.9.0

--- a/app/deploy/build.gradle
+++ b/app/deploy/build.gradle
@@ -39,3 +39,7 @@ tasks.register('composeDown') {
         }
     }
 }
+
+tasks.register('versionCheck', VersionCheckTask.class)  {
+    build.dependsOn it
+}

--- a/app/server/build.gradle
+++ b/app/server/build.gradle
@@ -84,6 +84,6 @@ tasks.register('dockerRun') {
     }
 }
 
-tasks.register('versionCheck') {
+tasks.register('versionCheck', VersionCheckTask.class)  {
     build.dependsOn it
 }

--- a/build.gradle
+++ b/build.gradle
@@ -72,13 +72,9 @@ subprojects {
 }
 
 ext.VERSION = new File("${rootDir}/VERSION").text
-tasks.register('versionCheck') {
-    build.dependsOn it
-    println versionDetails()
-    assert new File("${rootDir}/VERSION.md")
-            .text
-            .startsWith("# Version " + VERSION)
-}
+tasks.register('versionTag', VersionTagTask.class)
+tasks.register('versionHistory', VersionHistoryTask.class)
+tasks.register('versionRelease', VersionReleaseTask.class)
 
 tasks.register('lint') {
     dependsOn 'spotlessCheck'
@@ -89,7 +85,3 @@ tasks.register('format') {
     dependsOn 'spotlessApply'
     dependsOn ':app:client:prettierApply'
 }
-
-tasks.register('versionTag', VersionTagTask.class)
-tasks.register('versionHistory', VersionHistoryTask.class)
-tasks.register('versionRelease', VersionReleaseTask.class)

--- a/build.gradle
+++ b/build.gradle
@@ -89,3 +89,7 @@ tasks.register('format') {
     dependsOn 'spotlessApply'
     dependsOn ':app:client:prettierApply'
 }
+
+tasks.register('versionTag', VersionTagTask.class)
+tasks.register('versionHistory', VersionHistoryTask.class)
+tasks.register('versionRelease', VersionReleaseTask.class)

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // https://projectlombok.org
+    implementation('org.projectlombok:lombok:1.18.38')
+    annotationProcessor('org.projectlombok:lombok:1.18.38')
+    // https://projects.eclipse.org/projects/technology.jgit
+    implementation('org.eclipse.jgit:org.eclipse.jgit:7.3.0.202506031305-r')}
+dependencies {
+    // https://junit.org/junit5
+    testImplementation('org.junit.jupiter:junit-jupiter:5.12.2')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/buildSrc/src/main/java/JGit.java
+++ b/buildSrc/src/main/java/JGit.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.*;
+import java.util.function.Predicate;
 
 public final class JGit implements AutoCloseable {
 
@@ -104,14 +105,17 @@ public final class JGit implements AutoCloseable {
     /**
      * git log tag1..tag2 --oneline
      */
-    public List<String> listAllLog(@NonNull final String fromRef, @NonNull final String toRef) {
+    public List<String> listAllLog(@NonNull final String fromRef, @NonNull final String toRef, @NonNull final Predicate<String> commitTester) {
         try {
             final var allLog = new ArrayList<String>();
             final var fromId = git.getRepository().resolve(fromRef);
             final var toId = git.getRepository().resolve(toRef);
             final var allRevCommit = git.log().add(fromId).not(toId).call();
             for (final var revCommit : allRevCommit) {
-                allLog.add(revCommit.getShortMessage());
+                final var message = revCommit.getShortMessage();
+                if (commitTester.test(message)) {
+                    allLog.add(message);
+                }
             }
             return allLog;
         } catch (IOException e) {

--- a/buildSrc/src/main/java/JGit.java
+++ b/buildSrc/src/main/java/JGit.java
@@ -1,0 +1,135 @@
+import lombok.NonNull;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Ref;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTag;
+import org.eclipse.jgit.revwalk.RevWalk;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.*;
+
+public final class JGit implements AutoCloseable {
+
+    private final Git git;
+
+    private JGit(@NonNull final Git git) {
+        this.git = git;
+    }
+
+    public static JGit open(@NonNull final File rootDir) {
+        try {
+            return new JGit(Git.open(rootDir));
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        this.git.close();
+    }
+
+    /**
+     * git describe --tags --abbrev=0
+     */
+    public Optional<VersionTag> releaseTag() {
+        try {
+            final var tagName = "refs/tags/" + git.describe().setTags(true).setAbbrev(0).call();
+            final var tagRef = git.getRepository().findRef(tagName);
+            if (tagRef == null) {
+                throw new NoSuchElementException("'%s' not found".formatted(tagName));
+            }
+            final var tagCommit = parseCommit(tagRef);
+            final var commitAt = tagCommit.getCommitterIdent().getWhenAsInstant();
+            return VersionTag.cleanTag(tagName, commitAt);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (GitAPIException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    /**
+     * git describe --tags --abbrev=0
+     */
+    public Optional<VersionTag> versionTag() {
+        try {
+            final var tagName = "refs/tags/" + git.describe().setTags(true).setAbbrev(0).call();
+            final var tagRef = git.getRepository().findRef(tagName);
+            if (tagRef == null) {
+                throw new NoSuchElementException("'%s' not found".formatted(tagName));
+            }
+            final var tagCommit = parseCommit(tagRef);
+            final var fromId = git.getRepository().resolve("HEAD");;
+            final var toId = tagCommit.getId();
+            final var allRevCommit = git.log().add(fromId).not(toId).call();
+            if (allRevCommit.iterator().hasNext()) {
+                return VersionTag.dirtyTag(tagName);
+            } else {
+                final var commitAt = tagCommit.getCommitterIdent().getWhenAsInstant();
+                return VersionTag.cleanTag(tagName, commitAt);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (GitAPIException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    /**
+     * git for-each-ref --sort=-creatordate refs/tags
+     */
+    public List<VersionTag> listAllTag() {
+        try {
+            final var allTag = new ArrayList<VersionTag>();
+            final var allTagRef = git.tagList().call();
+            for (final var tagRef : allTagRef) {
+                final var tagName = tagRef.getName();
+                final var tagCommit = parseCommit(tagRef);
+                final var commitAt = tagCommit.getCommitterIdent().getWhenAsInstant();
+                VersionTag.cleanTag(tagName, commitAt).ifPresent(allTag::add);
+            }
+            Collections.sort(allTag);
+            return allTag;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (GitAPIException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    /**
+     * git log tag1..tag2 --oneline
+     */
+    public List<String> listAllLog(@NonNull final String fromRef, @NonNull final String toRef) {
+        try {
+            final var allLog = new ArrayList<String>();
+            final var fromId = git.getRepository().resolve(fromRef);
+            final var toId = git.getRepository().resolve(toRef);
+            final var allRevCommit = git.log().add(fromId).not(toId).call();
+            for (final var revCommit : allRevCommit) {
+                allLog.add(revCommit.getShortMessage());
+            }
+            return allLog;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (GitAPIException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
+    private RevCommit parseCommit(@NonNull final Ref tagRef) throws IOException {
+        try (final var walk = new RevWalk(git.getRepository())) {
+            final var id = tagRef.getObjectId();
+            final var rev = walk.parseAny(id);
+            if (rev instanceof RevTag revTag) {
+                return walk.parseCommit(walk.peel(revTag));
+            } else {
+                return walk.parseCommit(id);
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/MessageTester.java
+++ b/buildSrc/src/main/java/MessageTester.java
@@ -1,0 +1,17 @@
+import lombok.NonNull;
+
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class MessageTester implements Predicate<String> {
+
+    static final Pattern MESSAGE_PATTERN = Pattern.compile(
+            "^([a-z]+)(\\([a-zA-Z0-9_-]+\\))?!?:\\s*(.+)$"
+    );
+
+    @Override
+    public boolean test(@NonNull final String message) {
+        final var matcher = MESSAGE_PATTERN.matcher(message);
+        return matcher.matches();
+    }
+}

--- a/buildSrc/src/main/java/VersionCheckTask.java
+++ b/buildSrc/src/main/java/VersionCheckTask.java
@@ -1,0 +1,70 @@
+import lombok.NonNull;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class VersionCheckTask extends DefaultTask {
+
+    static final Pattern JSON_VERSION_PATTERN = Pattern.compile(
+            "\"version\"\\s*:\\s*\"(\\d+\\.\\d+\\.\\d+)\"");
+
+    static final Pattern YAML_VERSION_PATTERN = Pattern.compile(
+            "version\\s*:\\s*(\\d+\\.\\d+\\.\\d+)");
+
+    @TaskAction
+    public void task() {
+        try (final var git = JGit.open(getProject().getRootDir())) {
+            final var cleanTag = git.releaseTag();
+            final var localTag = git.versionTag();
+            checkTag(localTag, cleanTag);
+            final var projectDir = getProject().getLayout().getProjectDirectory();
+            List.of("package.json", "package-lock.json").forEach(filename ->
+                    checkVersion(JSON_VERSION_PATTERN, localTag, projectDir.file(filename).getAsFile()));
+            List.of("Chart.yaml").forEach(filename ->
+                    checkVersion(YAML_VERSION_PATTERN, localTag, projectDir.file(filename).getAsFile()));
+        }
+    }
+
+    private @NotNull Path toFilename(@NotNull final File file) {
+        return getProject().getRootDir().toPath().relativize(file.toPath());
+    }
+
+    private void checkTag(@NonNull final VersionTag localTag, @NonNull final VersionTag cleanTag) {
+        if (!localTag.followsAfter(cleanTag)) {
+            throw new IllegalStateException("local tag '%s' does not follow clean tag '%s'".formatted(
+                    localTag.toSemVer(), cleanTag.toSemVer()
+            ));
+        }
+    }
+
+    private void checkVersion(@NonNull final Pattern pattern, @NonNull final VersionTag localTag, @NonNull final File file) {
+        if (file.exists()) {
+            try {
+                final var content = Files.readString(file.toPath());
+                final var matcher = pattern.matcher(content);
+                if (matcher.find()) {
+                    final var version = matcher.group(1);
+                    if (!version.startsWith(localTag.toSemVer())) {
+                        throw new IllegalStateException("%s: version '%s' does not match tag '%s'".formatted(
+                                toFilename(file), version, localTag.toSemVer()
+                        ));
+                    }
+                } else {
+                    throw new IllegalStateException("%s: version does not exist".formatted(
+                            toFilename(file)
+                    ));
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionHistoryTask.java
+++ b/buildSrc/src/main/java/VersionHistoryTask.java
@@ -3,6 +3,8 @@ import org.gradle.api.tasks.TaskAction;
 
 public class VersionHistoryTask extends DefaultTask {
 
+    private final MessageTester messageTester = new MessageTester();
+
     @TaskAction
     public void task() {
         final var project = getProject();
@@ -11,7 +13,7 @@ public class VersionHistoryTask extends DefaultTask {
             for (int i = 1; i < allTag.size(); i++) {
                 final var fromTag = allTag.get(i - 1).toString();
                 final var toTag = allTag.get(i).toString();
-                final var allLog = git.listAllLog(fromTag, toTag);
+                final var allLog = git.listAllLog(fromTag, toTag, messageTester);
                 System.out.println(fromTag.replace("refs/tags/", "# Version "));
                 System.out.println();
                 allLog.forEach(log -> System.out.println("* " + log));

--- a/buildSrc/src/main/java/VersionHistoryTask.java
+++ b/buildSrc/src/main/java/VersionHistoryTask.java
@@ -3,20 +3,18 @@ import org.gradle.api.tasks.TaskAction;
 
 public class VersionHistoryTask extends DefaultTask {
 
-    private final MessageTester messageTester = new MessageTester();
-
     @TaskAction
     public void task() {
         final var project = getProject();
         try (final var git = JGit.open(project.getRootDir())) {
             final var allTag = git.listAllTag();
             for (int i = 1; i < allTag.size(); i++) {
-                final var fromTag = allTag.get(i - 1).toString();
-                final var toTag = allTag.get(i).toString();
-                final var allLog = git.listAllLog(fromTag, toTag, messageTester);
-                System.out.println(fromTag.replace("refs/tags/", "# Version "));
+                final var fromTag = allTag.get(i - 1);
+                final var toTag = allTag.get(i);
+                final var allLog = git.listAllLog(fromTag.toRef(), toTag.toRef());
+                System.out.printf("# Version %s%n", fromTag.toSemVer());
                 System.out.println();
-                allLog.forEach(log -> System.out.println("* " + log));
+                allLog.forEach(log -> System.out.printf("* %s%n", log));
                 System.out.println();
             }
         }

--- a/buildSrc/src/main/java/VersionHistoryTask.java
+++ b/buildSrc/src/main/java/VersionHistoryTask.java
@@ -1,0 +1,22 @@
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class VersionHistoryTask extends DefaultTask {
+
+    @TaskAction
+    public void task() {
+        final var project = getProject();
+        try (final var git = JGit.open(project.getRootDir())) {
+            final var allTag = git.listAllTag();
+            for (int i = 1; i < allTag.size(); i++) {
+                final var fromTag = allTag.get(i - 1).toString();
+                final var toTag = allTag.get(i).toString();
+                final var allLog = git.listAllLog(fromTag, toTag);
+                System.out.println(fromTag.replace("refs/tags/", "# Version "));
+                System.out.println();
+                allLog.forEach(log -> System.out.println("* " + log));
+                System.out.println();
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionHistoryTask.java
+++ b/buildSrc/src/main/java/VersionHistoryTask.java
@@ -5,8 +5,7 @@ public class VersionHistoryTask extends DefaultTask {
 
     @TaskAction
     public void task() {
-        final var project = getProject();
-        try (final var git = JGit.open(project.getRootDir())) {
+        try (final var git = JGit.open(getProject().getRootDir())) {
             final var allTag = git.listAllTag();
             for (int i = 1; i < allTag.size(); i++) {
                 final var fromTag = allTag.get(i - 1);

--- a/buildSrc/src/main/java/VersionReleaseTask.java
+++ b/buildSrc/src/main/java/VersionReleaseTask.java
@@ -3,17 +3,14 @@ import org.gradle.api.tasks.TaskAction;
 
 public class VersionReleaseTask extends DefaultTask {
 
-    private final MessageTester messageTester = new MessageTester();
-
     @TaskAction
     public void task() {
         final var project = getProject();
         try (final var git = JGit.open(project.getRootDir())) {
-            git.releaseTag().ifPresent(toTag -> {
-                final var allLog = git.listAllLog("HEAD", toTag.toString(), messageTester);
-                allLog.forEach(log -> System.out.println("* " + log));
-                System.out.println();
-            });
+            final var toTag = git.releaseTag();
+            final var allLog = git.listAllLog("HEAD", toTag.toRef());
+            allLog.forEach(log -> System.out.printf("* %s%n", log));
+            System.out.println();
         }
     }
 }

--- a/buildSrc/src/main/java/VersionReleaseTask.java
+++ b/buildSrc/src/main/java/VersionReleaseTask.java
@@ -1,0 +1,17 @@
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class VersionReleaseTask extends DefaultTask {
+
+    @TaskAction
+    public void task() {
+        final var project = getProject();
+        try (final var git = JGit.open(project.getRootDir())) {
+            git.releaseTag().ifPresent(toTag -> {
+                final var allLog = git.listAllLog("HEAD", toTag.toString());
+                allLog.forEach(log -> System.out.println("* " + log));
+                System.out.println();
+            });
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionReleaseTask.java
+++ b/buildSrc/src/main/java/VersionReleaseTask.java
@@ -5,8 +5,7 @@ public class VersionReleaseTask extends DefaultTask {
 
     @TaskAction
     public void task() {
-        final var project = getProject();
-        try (final var git = JGit.open(project.getRootDir())) {
+        try (final var git = JGit.open(getProject().getRootDir())) {
             final var toTag = git.releaseTag();
             final var allLog = git.listAllLog("HEAD", toTag.toRef());
             allLog.forEach(log -> System.out.printf("* %s%n", log));

--- a/buildSrc/src/main/java/VersionReleaseTask.java
+++ b/buildSrc/src/main/java/VersionReleaseTask.java
@@ -3,12 +3,14 @@ import org.gradle.api.tasks.TaskAction;
 
 public class VersionReleaseTask extends DefaultTask {
 
+    private final MessageTester messageTester = new MessageTester();
+
     @TaskAction
     public void task() {
         final var project = getProject();
         try (final var git = JGit.open(project.getRootDir())) {
             git.releaseTag().ifPresent(toTag -> {
-                final var allLog = git.listAllLog("HEAD", toTag.toString());
+                final var allLog = git.listAllLog("HEAD", toTag.toString(), messageTester);
                 allLog.forEach(log -> System.out.println("* " + log));
                 System.out.println();
             });

--- a/buildSrc/src/main/java/VersionTag.java
+++ b/buildSrc/src/main/java/VersionTag.java
@@ -1,18 +1,11 @@
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
+import lombok.*;
 
 import java.time.Instant;
-import java.util.Optional;
-import java.util.regex.Pattern;
 
 @EqualsAndHashCode
+@ToString
 @Getter
 public final class VersionTag implements Comparable<VersionTag> {
-
-    static final Pattern VERSION_PATTERN = Pattern.compile(
-            "^refs/tags/(\\d+)\\.(\\d+)$"
-    );
 
     private final int major;
 
@@ -20,14 +13,10 @@ public final class VersionTag implements Comparable<VersionTag> {
 
     private final Instant commitAt;
 
-    VersionTag(final int major, final int minor, @NonNull final Instant commitAt) {
-        this.major = major;
-        this.minor = minor;
+    public VersionTag(final int[] version, @NonNull final Instant commitAt) {
+        this.major = version[0];
+        this.minor = version[1];
         this.commitAt = commitAt;
-    }
-
-    public VersionTag increment() {
-        return new VersionTag(major, minor + 1, Instant.now());
     }
 
     @Override
@@ -45,30 +34,11 @@ public final class VersionTag implements Comparable<VersionTag> {
         return 0;
     }
 
-    @Override
-    public String toString() {
+    public String toRef() {
         return "refs/tags/%d.%d".formatted(major, minor);
     }
 
-    static Optional<VersionTag> cleanTag(@NonNull final String tagName, @NonNull final Instant commitAt) {
-        final var matcher = VERSION_PATTERN.matcher(tagName);
-        if (matcher.matches()) {
-            final var major = Integer.parseInt(matcher.group(1));
-            final var minor = Integer.parseInt(matcher.group(2));
-            return Optional.of(new VersionTag(major, minor, commitAt));
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    static Optional<VersionTag> dirtyTag(@NonNull final String tagName) {
-        final var matcher = VERSION_PATTERN.matcher(tagName);
-        if (matcher.matches()) {
-            final var major = Integer.parseInt(matcher.group(1));
-            final var minor = Integer.parseInt(matcher.group(2)) + 1;
-            return Optional.of(new VersionTag(major, minor, Instant.now()));
-        } else {
-            return Optional.empty();
-        }
+    public String toSemVer() {
+        return "%d.%d".formatted(major, minor);
     }
 }

--- a/buildSrc/src/main/java/VersionTag.java
+++ b/buildSrc/src/main/java/VersionTag.java
@@ -34,6 +34,16 @@ public final class VersionTag implements Comparable<VersionTag> {
         return 0;
     }
 
+    public boolean followsAfter(@NonNull final VersionTag that) {
+        if (that.major != this.major) {
+            return that.major < this.major;
+        }
+        if (that.minor != this.minor) {
+            return that.minor < this.minor;
+        }
+        return false;
+    }
+
     public String toRef() {
         return "refs/tags/%d.%d".formatted(major, minor);
     }

--- a/buildSrc/src/main/java/VersionTag.java
+++ b/buildSrc/src/main/java/VersionTag.java
@@ -1,0 +1,74 @@
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+@EqualsAndHashCode
+@Getter
+public final class VersionTag implements Comparable<VersionTag> {
+
+    static final Pattern VERSION_PATTERN = Pattern.compile(
+            "^refs/tags/(\\d+)\\.(\\d+)$"
+    );
+
+    private final int major;
+
+    private final int minor;
+
+    private final Instant commitAt;
+
+    VersionTag(final int major, final int minor, @NonNull final Instant commitAt) {
+        this.major = major;
+        this.minor = minor;
+        this.commitAt = commitAt;
+    }
+
+    public VersionTag increment() {
+        return new VersionTag(major, minor + 1, Instant.now());
+    }
+
+    @Override
+    public int compareTo(@NonNull final VersionTag that) {
+        // descending by commit time, major and minor
+        if (!that.commitAt.equals(this.commitAt)) {
+            return that.commitAt.compareTo(this.commitAt);
+        }
+        if (that.major != this.major) {
+            return Integer.compare(that.major, this.major);
+        }
+        if (that.minor != this.minor) {
+            return Integer.compare(that.minor, this.minor);
+        }
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "refs/tags/%d.%d".formatted(major, minor);
+    }
+
+    static Optional<VersionTag> cleanTag(@NonNull final String tagName, @NonNull final Instant commitAt) {
+        final var matcher = VERSION_PATTERN.matcher(tagName);
+        if (matcher.matches()) {
+            final var major = Integer.parseInt(matcher.group(1));
+            final var minor = Integer.parseInt(matcher.group(2));
+            return Optional.of(new VersionTag(major, minor, commitAt));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    static Optional<VersionTag> dirtyTag(@NonNull final String tagName) {
+        final var matcher = VERSION_PATTERN.matcher(tagName);
+        if (matcher.matches()) {
+            final var major = Integer.parseInt(matcher.group(1));
+            final var minor = Integer.parseInt(matcher.group(2)) + 1;
+            return Optional.of(new VersionTag(major, minor, Instant.now()));
+        } else {
+            return Optional.empty();
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionTagTask.java
+++ b/buildSrc/src/main/java/VersionTagTask.java
@@ -5,8 +5,7 @@ public class VersionTagTask extends DefaultTask {
 
     @TaskAction
     public void task() {
-        final var project = getProject();
-        try (final var git = JGit.open(project.getRootDir())) {
+        try (final var git = JGit.open(getProject().getRootDir())) {
             final var toTag = git.versionTag();
             System.out.println(toTag.toSemVer());
         }

--- a/buildSrc/src/main/java/VersionTagTask.java
+++ b/buildSrc/src/main/java/VersionTagTask.java
@@ -7,7 +7,8 @@ public class VersionTagTask extends DefaultTask {
     public void task() {
         final var project = getProject();
         try (final var git = JGit.open(project.getRootDir())) {
-            git.versionTag().ifPresent(System.out::println);
+            final var toTag = git.versionTag();
+            System.out.println(toTag.toSemVer());
         }
     }
 }

--- a/buildSrc/src/main/java/VersionTagTask.java
+++ b/buildSrc/src/main/java/VersionTagTask.java
@@ -1,0 +1,13 @@
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class VersionTagTask extends DefaultTask {
+
+    @TaskAction
+    public void task() {
+        final var project = getProject();
+        try (final var git = JGit.open(project.getRootDir())) {
+            git.versionTag().ifPresent(System.out::println);
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionTester.java
+++ b/buildSrc/src/main/java/VersionTester.java
@@ -1,0 +1,30 @@
+import lombok.NonNull;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+
+public class VersionTester implements Predicate<String>, Function<String, int[]> {
+
+    static final Pattern VERSION_PATTERN = Pattern.compile(
+            "^refs/tags/v?(\\d+)\\.(\\d+).*$"
+    );
+
+    @Override
+    public boolean test(@NonNull final String version) {
+        final var matcher = VERSION_PATTERN.matcher(version);
+        return matcher.matches();
+    }
+
+    @Override
+    public int[] apply(@NonNull final String version) {
+        final var matcher = VERSION_PATTERN.matcher(version);
+        if (matcher.matches()) {
+            final var major = Integer.parseInt(matcher.group(1));
+            final var minor = Integer.parseInt(matcher.group(2));
+            return new int[]{major, minor};
+        } else {
+            return new int[]{0, 0};
+        }
+    }
+}

--- a/buildSrc/src/test/java/MessageTesterTest.java
+++ b/buildSrc/src/test/java/MessageTesterTest.java
@@ -1,0 +1,38 @@
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MessageTesterTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "fix",
+            "feat",
+            "spike",
+            "build",
+            "doc",
+            "refactor",
+            "renovate"
+    })
+    void messageOk(final String typ) {
+        final var classUnderTest = new MessageTester();
+        assertTrue(classUnderTest.test("%s: Lorem ipsum".formatted(typ)));
+        assertTrue(classUnderTest.test("%s(scope): Lorem ipsum".formatted(typ)));
+        assertTrue(classUnderTest.test("%s!: Lorem ipsum".formatted(typ)));
+        assertTrue(classUnderTest.test("%s(scope)!: Lorem ipsum".formatted(typ)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "fix me",
+            "fix me:",
+            "fix()",
+            "fix(me too)"
+    })
+    void messageNotOk(final String message) {
+        final var classUnderTest = new MessageTester();
+        assertFalse(classUnderTest.test(message));
+    }
+}

--- a/buildSrc/src/test/java/VersionTagTest.java
+++ b/buildSrc/src/test/java/VersionTagTest.java
@@ -29,4 +29,14 @@ class VersionTagTest {
         assertEquals(List.of(0, 3, 2, 1), allTagSorted.stream().map(VersionTag::getMinor).toList());
     }
 
+    @Test
+    void followsAfter() {
+        final var now = Instant.now();
+        final var tag = new VersionTag(new int[]{1,2}, now);
+        assertTrue(tag.followsAfter(new VersionTag(new int[]{0,2}, now)));
+        assertTrue(tag.followsAfter(new VersionTag(new int[]{1,1}, now)));
+        assertFalse(tag.followsAfter(new VersionTag(new int[]{1,2}, now)));
+        assertFalse(tag.followsAfter(new VersionTag(new int[]{1,3}, now)));
+        assertFalse(tag.followsAfter(new VersionTag(new int[]{2,0}, now)));
+    }
 }

--- a/buildSrc/src/test/java/VersionTagTest.java
+++ b/buildSrc/src/test/java/VersionTagTest.java
@@ -1,6 +1,4 @@
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Instant;
 import java.util.List;
@@ -10,42 +8,23 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class VersionTagTest {
 
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "refs/tags/0.0",
-            "refs/tags/0.9",
-            "refs/tags/1.20"
-    })
-    void tagNameOk(final String tagName) {
+    @Test
+    void stringify() {
         final var now = Instant.now();
-        final var cleanTag = VersionTag.cleanTag(tagName, now).orElseThrow();
-        assertEquals(tagName, cleanTag.toString());
-        final var dirtyTag = VersionTag.dirtyTag(tagName).orElseThrow();
-        assertNotEquals(tagName, dirtyTag.toString());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "0.0",
-            "refs/tags/0",
-            "refs/tags/a.0",
-            "refs/tags/0.a",
-            "refs/tags/0.0.0"
-    })
-    void tagNameNotOk(final String tagName) {
-        final var now = Instant.now();
-        assertFalse(VersionTag.cleanTag(tagName, now).isPresent());
-        assertFalse(VersionTag.dirtyTag(tagName).isPresent());
+        final var tag = new VersionTag(new int[]{0,2}, now);
+        assertEquals("refs/tags/0.2", tag.toRef());
+        assertEquals("0.2", tag.toSemVer());
+        assertFalse(tag.toString().isBlank());
     }
 
     @Test
     void compareTo() {
         final var now = Instant.now();
         final var allTagSorted = new TreeSet<VersionTag>();
-        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.1", now.minusMillis(1L)).orElseThrow());
-        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.2", now).orElseThrow());
-        allTagSorted.add(VersionTag.cleanTag("refs/tags/1.0", now.plusMillis(1L)).orElseThrow());
-        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.3", now.plusMillis(1L)).orElseThrow());
+        allTagSorted.add(new VersionTag(new int[]{0,1}, now.minusMillis(1L)));
+        allTagSorted.add(new VersionTag(new int[]{0,2}, now));
+        allTagSorted.add(new VersionTag(new int[]{1,0}, now.plusMillis(1L)));
+        allTagSorted.add(new VersionTag(new int[]{0,3}, now.plusMillis(1L)));
         assertEquals(List.of(1, 0, 0, 0), allTagSorted.stream().map(VersionTag::getMajor).toList());
         assertEquals(List.of(0, 3, 2, 1), allTagSorted.stream().map(VersionTag::getMinor).toList());
     }

--- a/buildSrc/src/test/java/VersionTagTest.java
+++ b/buildSrc/src/test/java/VersionTagTest.java
@@ -1,0 +1,53 @@
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VersionTagTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "refs/tags/0.0",
+            "refs/tags/0.9",
+            "refs/tags/1.20"
+    })
+    void tagNameOk(final String tagName) {
+        final var now = Instant.now();
+        final var cleanTag = VersionTag.cleanTag(tagName, now).orElseThrow();
+        assertEquals(tagName, cleanTag.toString());
+        final var dirtyTag = VersionTag.dirtyTag(tagName).orElseThrow();
+        assertNotEquals(tagName, dirtyTag.toString());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "0.0",
+            "refs/tags/0",
+            "refs/tags/a.0",
+            "refs/tags/0.a",
+            "refs/tags/0.0.0"
+    })
+    void tagNameNotOk(final String tagName) {
+        final var now = Instant.now();
+        assertFalse(VersionTag.cleanTag(tagName, now).isPresent());
+        assertFalse(VersionTag.dirtyTag(tagName).isPresent());
+    }
+
+    @Test
+    void compareTo() {
+        final var now = Instant.now();
+        final var allTagSorted = new TreeSet<VersionTag>();
+        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.1", now.minusMillis(1L)).orElseThrow());
+        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.2", now).orElseThrow());
+        allTagSorted.add(VersionTag.cleanTag("refs/tags/1.0", now.plusMillis(1L)).orElseThrow());
+        allTagSorted.add(VersionTag.cleanTag("refs/tags/0.3", now.plusMillis(1L)).orElseThrow());
+        assertEquals(List.of(1, 0, 0, 0), allTagSorted.stream().map(VersionTag::getMajor).toList());
+        assertEquals(List.of(0, 3, 2, 1), allTagSorted.stream().map(VersionTag::getMinor).toList());
+    }
+
+}

--- a/buildSrc/src/test/java/VersionTesterTest.java
+++ b/buildSrc/src/test/java/VersionTesterTest.java
@@ -1,0 +1,42 @@
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class VersionTesterTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "refs/tags/1.2",
+            "refs/tags/1.2.0",
+            "refs/tags/1.2.0-alpha",
+            "refs/tags/v1.2"
+    })
+    void versionOk(final String tagName) {
+        final var classUnderTest = new VersionTester();
+        assertTrue(classUnderTest.test(tagName));
+        assertEquals("[1, 2]", Arrays.toString(classUnderTest.apply(tagName)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "1.2",
+            "refs/1.2",
+            "tags/1.2",
+            "ref/tags1.2",
+            "refs/tag/1.2",
+            "refs/tags/1",
+            "refs/tags/1.",
+            "refs/tags/1.a",
+            "refs/tags/x1.2"
+    })
+    void versionNotOk(final String tagName) {
+        final var classUnderTest = new VersionTester();
+        assertFalse(classUnderTest.test(tagName));
+        assertEquals("[0, 0]", Arrays.toString(classUnderTest.apply(tagName)));
+    }
+}

--- a/lib/backend-data/src/main/java/esy/app/EsyBackendControllerAdvice.java
+++ b/lib/backend-data/src/main/java/esy/app/EsyBackendControllerAdvice.java
@@ -45,7 +45,6 @@ import java.util.NoSuchElementException;
 @RestController
 public class EsyBackendControllerAdvice extends ResponseEntityExceptionHandler implements ErrorController {
 
-
     /**
      * @see org.springframework.data.rest.webmvc.RepositoryRestExceptionHandler
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "petclinic",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
- `versionHistory` erzeugt ein komplettes Changelog für alle Tags
- `versionRelease` erzeugt ein Changelog für den nächsten Tag. Der nächste Tag wird durch den Inhalt von VERSION bestimmt. Die nächste Version muss semantisch nach der Version im letzten Tag sein.
- `versionTag` zeigt den aktuellen Tag an
- `versionCheck` prüft, ob der Inhalt von VERSION korrekt ist, ob alle Versionsangaben in anderen Dateien (z.:B package.json oder Charts.yaml) korrekt sind.
- `versionApply` aktualisiert alle Versionsangaben in anderen Dateien (z.:B package.json oder Charts.yaml) passend zum Inhalt von VERSION sind.

https://www.conventionalcommits.org/

https://semver.org/

https://github.com/marketplace/semantic-prs

https://commitlint.js.org
