### PR TITLE
example: Neues Domänenobjekt Invoice (DO NOT MERGE)

### DIFF
--- a/app/client-angular/src/main/angular/app.html
+++ b/app/client-angular/src/main/angular/app.html
@@ -69,6 +69,14 @@
                 <a
                   class="link"
                   (click)="onMenuClose($event)"
+                  routerLink="/invoice"
+                  >Invoice</a
+                >
+              </li>
+              <li>
+                <a
+                  class="link"
+                  (click)="onMenuClose($event)"
                   routerLink="/visit"
                   >Visit</a
                 >

--- a/app/client-angular/src/main/angular/app.routes.ts
+++ b/app/client-angular/src/main/angular/app.routes.ts
@@ -23,6 +23,11 @@ export const routes: Routes = [
       import("./pages/client/pet.routes").then((m) => m.routes),
   },
   {
+    path: "invoice",
+    loadChildren: () =>
+      import("./pages/clinic/invoice.routes").then((m) => m.routes),
+  },
+  {
     path: "vet",
     loadChildren: () =>
       import("./pages/clinic/vet.routes").then((m) => m.routes),

--- a/app/client-angular/src/main/angular/pages/clinic/invoice-editor/invoice-editor.html
+++ b/app/client-angular/src/main/angular/pages/clinic/invoice-editor/invoice-editor.html
@@ -1,0 +1,92 @@
+<form [formGroup]="form" (ngSubmit)="onSubmitClicked()">
+  <div class="flex flex-col gap-2 pt-4">
+    <div class="flex flex-col gap-2 sm:flex-row">
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Issue Date</legend>
+        <input
+          formControlName="issued"
+          aria-label="Issue Date"
+          type="date"
+          class="input input-bordered w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Payment period in days</legend>
+        <input
+          formControlName="days"
+          aria-label="Payment period in days"
+          type="number"
+          min="0"
+          class="input input-bordered w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Status</legend>
+        <select
+          formControlName="status"
+          aria-label="Status"
+          class="select w-full"
+        >
+          <option value="D">drafted</option>
+          <option value="I">issued</option>
+          <option value="C">completed</option>
+          <option value="X">cancelled</option>
+        </select>
+      </fieldset>
+    </div>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Visit</legend>
+      <div class="relative">
+        <input
+          [value]="visitFilter()"
+          (input)="onVisitFilterInput($event)"
+          (keydown)="onVisitKeyDown($event)"
+          aria-label="Filter visits"
+          aria-autocomplete="list"
+          [attr.aria-expanded]="allVisitItem().length > 0"
+          type="text"
+          class="input input-bordered w-full"
+          placeholder="Type to search visits…"
+          autocomplete="off"
+        />
+        @if (allVisitItem().length > 0) {
+          <ul
+            class="absolute z-10 w-full bg-base-100 border border-base-300 rounded-box shadow-lg mt-1 max-h-60 overflow-y-auto"
+            role="listbox"
+          >
+            @for (item of allVisitItem(); track item.value; let i = $index) {
+              <li
+                role="option"
+                [attr.aria-selected]="item.value === selectedVisitId()"
+                class="px-3 py-2 cursor-pointer"
+                [class.bg-primary]="i === visitKeyIndex()"
+                [class.text-primary-content]="i === visitKeyIndex()"
+                [class.hover:bg-base-200]="i !== visitKeyIndex()"
+                (mousedown)="onVisitSelected(item)"
+              >
+                {{ item.text }}
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    </fieldset>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Text</legend>
+      <textarea
+        formControlName="text"
+        aria-label="Text"
+        class="textarea w-full"
+        placeholder="Enter invoice description"
+      ></textarea>
+    </fieldset>
+  </div>
+  <div class="join py-4">
+    <button type="submit" class="btn join-item" [disabled]="!isSubmittable">
+      Ok
+    </button>
+    <button type="button" class="btn join-item" (click)="onCancelClicked()">
+      Cancel
+    </button>
+  </div>
+</form>

--- a/app/client-angular/src/main/angular/pages/clinic/invoice-editor/invoice-editor.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/invoice-editor/invoice-editor.ts
@@ -1,0 +1,180 @@
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  inject,
+  input,
+  model,
+  output,
+  signal,
+} from "@angular/core";
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { Subject, debounceTime, distinctUntilChanged, switchMap } from "rxjs";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
+import { Toast } from "../../../controls/toast/toast";
+import { InvoiceService } from "../../../services/invoice.service";
+import { VisitService } from "../../../services/visit.service";
+import { type VisitItem } from "../../../types/visit.type";
+import { type Invoice, type InvoiceStatus } from "../../../types/invoice.type";
+
+@Component({
+  selector: "app-invoice-editor",
+  imports: [ReactiveFormsModule],
+  templateUrl: "./invoice-editor.html",
+  styles: ``,
+})
+export class InvoiceEditorComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+  private toast = inject(Toast);
+  private invoiceService = inject(InvoiceService);
+  private visitService = inject(VisitService);
+  visible = model.required<boolean>();
+  invoice = input.required<Invoice>();
+  form = new FormGroup({
+    issued: new FormControl("", Validators.required),
+    days: new FormControl(0, [Validators.required, Validators.min(0)]),
+    status: new FormControl<InvoiceStatus>("D", Validators.required),
+    text: new FormControl("", [Validators.required, Validators.minLength(1)]),
+  });
+
+  allVisitItem = signal<VisitItem[]>([]);
+  selectedVisitId = signal<string | null>(null);
+  visitKeyIndex = signal(-1);
+  visitFilter = signal("");
+  private visitFilter$ = new Subject<string>();
+
+  private parseDays(iso: string): number {
+    const match = /PT(\d+)H/.exec(iso ?? "");
+    const hours = match?.[1] ? parseInt(match[1], 10) : 0;
+    return Math.round(hours / 24);
+  }
+
+  private buildPeriod(days: number): string {
+    if (days === 0) return "PT0S";
+    return `PT${days * 24}H`;
+  }
+
+  ngOnInit() {
+    const days = this.parseDays(this.invoice().period);
+    this.form.patchValue({ ...this.invoice(), days });
+    this.selectedVisitId.set(this.invoice().visit ?? null);
+
+    this.visitFilter$
+      .pipe(
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((text) => this.visitService.loadAllVisitByText(text)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: (items) => {
+          this.allVisitItem.set(items);
+        },
+        error: (err) => {
+          this.toast.push(err);
+        },
+      });
+  }
+
+  onVisitFilterInput(event: Event) {
+    const text = (event.target as HTMLInputElement).value;
+    this.visitFilter.set(text);
+    this.visitKeyIndex.set(-1);
+    if (text.length >= 2) {
+      this.visitFilter$.next(text);
+    } else {
+      this.allVisitItem.set([]);
+    }
+  }
+
+  onVisitKeyDown(event: KeyboardEvent) {
+    if (!this.allVisitItem().length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      this.visitKeyIndex.update((i) =>
+        Math.min(i + 1, this.allVisitItem().length - 1)
+      );
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      this.visitKeyIndex.update((i) => Math.max(i - 1, 0));
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      const idx = this.visitKeyIndex();
+      if (idx >= 0) this.onVisitSelected(this.allVisitItem()[idx]);
+    } else if (event.key === "Escape" || event.key === "Tab") {
+      this.allVisitItem.set([]);
+      this.visitKeyIndex.set(-1);
+    }
+  }
+
+  onVisitSelected(item: VisitItem) {
+    this.selectedVisitId.set(item.value);
+    this.visitFilter.set(item.text);
+    this.allVisitItem.set([]);
+    this.visitKeyIndex.set(-1);
+  }
+
+  get isSubmittable() {
+    return this.form.dirty && this.form.valid;
+  }
+
+  cancelEmitter = output<Invoice>({ alias: "cancel" });
+  onCancelClicked() {
+    this.cancelEmitter.emit(this.invoice());
+    this.visible.set(false);
+    this.form.reset();
+  }
+
+  createEmitter = output<Invoice>({ alias: "create" });
+  updateEmitter = output<Invoice>({ alias: "update" });
+  onSubmitClicked() {
+    const newInvoice: Invoice = {
+      ...this.invoice(),
+      issued: this.form.value.issued!,
+      period: this.buildPeriod(this.form.value.days ?? 0),
+      status: this.form.value.status!,
+      text: this.form.value.text!,
+      visit: this.selectedVisitId()
+        ? `/api/visit/${this.selectedVisitId()}`
+        : this.invoice().visit,
+    };
+    if (this.invoice().id) {
+      const subscription = this.invoiceService
+        .mutateInvoice(this.invoice().id!, newInvoice)
+        .subscribe({
+          next: (value) => {
+            this.updateEmitter.emit(value);
+            this.visible.set(false);
+            this.form.reset();
+          },
+          error: (err) => {
+            this.toast.push(err);
+          },
+        });
+      this.destroyRef.onDestroy(() => {
+        subscription.unsubscribe();
+      });
+    } else {
+      const subscription = this.invoiceService
+        .createInvoice(newInvoice)
+        .subscribe({
+          next: (value) => {
+            this.createEmitter.emit(value);
+            this.visible.set(false);
+            this.form.reset();
+          },
+          error: (err) => {
+            this.toast.push(err);
+          },
+        });
+      this.destroyRef.onDestroy(() => {
+        subscription.unsubscribe();
+      });
+    }
+  }
+}

--- a/app/client-angular/src/main/angular/pages/clinic/invoice-lister/invoice-lister.html
+++ b/app/client-angular/src/main/angular/pages/clinic/invoice-lister/invoice-lister.html
@@ -1,0 +1,116 @@
+<h1>Invoice</h1>
+
+<div class="flex flex-col gap-1 ml-2 mr-2">
+  <form [formGroup]="filterForm" (ngSubmit)="onFilterClicked()">
+    <div class="flex flex-row gap-2 items-center pb-2 pr-2">
+      <input
+        formControlName="criteria"
+        aria-label="Filter"
+        type="text"
+        class="input input-bordered w-full"
+        [readonly]="invoiceFilterDisabled()"
+        placeholder="Enter filter criteria"
+      />
+      <button
+        type="submit"
+        title="Filter items"
+        class="btn btn-circle btn-outline"
+        [disabled]="invoiceFilterDisabled()"
+      >
+        <span class="material-icons">search</span>
+      </button>
+    </div>
+  </form>
+  @if (loading()) {
+    <div class="h-screen flex justify-center items-start">
+      <span class="loading loading-spinner loading-xl"></span>
+    </div>
+  } @else {
+    <table class="table-fixed">
+      <thead class="justify-between">
+        <tr class="bg-gray-200">
+          <th class="px-2 py-3 text-left w-1/4 table-cell">
+            <span class="text-gray-600">Issue Date</span>
+          </th>
+          <th class="px-2 py-3 text-left w-full table-cell">
+            <span class="text-gray-600">Text</span>
+          </th>
+          <th class="px-2 py-3 text-right w-16 table-cell">
+            <button
+              title="Add a new invoice"
+              class="btn btn-circle btn-outline"
+              (click)="onInvoiceEditorCreateClicked()"
+              [disabled]="invoiceEditorDisabled()"
+            >
+              <span class="material-icons">add</span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        @if (invoiceEditorCreate()) {
+          <tr>
+            <td class="border-l-4 px-2" colspan="3">
+              <app-invoice-editor
+                (create)="afterCreateInvoice($event)"
+                [(visible)]="invoiceEditorCreate"
+                [invoice]="newInvoice()"
+              />
+            </td>
+          </tr>
+        }
+        @for (invoice of allInvoice(); track invoice.id) {
+          <tr
+            [title]="invoice.issued"
+            [class.border-l-2]="invoiceId() === invoice.id"
+            (click)="onInvoiceClicked(invoice)"
+          >
+            <td class="px-2 py-3 text-left table-cell">
+              {{ invoice.issued }}
+            </td>
+            <td class="px-2 py-3 text-left table-cell">
+              {{ invoice.text }}
+            </td>
+            <td class="px-2 py-3 table-cell">
+              <div
+                class="grid grid-cols-1 md:grid-cols-2 items-center gap-1 w-max"
+              >
+                <button
+                  title="Delete an invoice"
+                  class="btn btn-circle btn-outline"
+                  (click)="onInvoiceRemoveClicked(invoice)"
+                  [disabled]="invoiceEditorDisabled()"
+                >
+                  <span class="material-icons">delete</span>
+                </button>
+                <button
+                  title="Edit an invoice"
+                  class="btn btn-circle btn-outline"
+                  (click)="onInvoiceEditorUpdateClicked(invoice)"
+                  [disabled]="invoiceEditorDisabled()"
+                >
+                  <span class="material-icons">edit</span>
+                </button>
+              </div>
+            </td>
+          </tr>
+          @if (invoiceEditorUpdate() && invoiceId() === invoice.id) {
+            <tr>
+              <td class="border-l-4 px-2" colspan="3">
+                <app-invoice-editor
+                  (update)="afterUpdateInvoice($event)"
+                  [(visible)]="invoiceEditorUpdate"
+                  [invoice]="invoice"
+                />
+              </td>
+            </tr>
+          }
+        } @empty {
+          <tr>
+            <td class="px-2" colspan="3">No invoices</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  }
+</div>

--- a/app/client-angular/src/main/angular/pages/clinic/invoice-lister/invoice-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/invoice-lister/invoice-lister.ts
@@ -1,0 +1,147 @@
+import {
+  Component,
+  DestroyRef,
+  OnInit,
+  computed,
+  effect,
+  inject,
+  signal,
+} from "@angular/core";
+import { CommonModule } from "@angular/common";
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import { Toast } from "../../../controls/toast/toast";
+import { InvoiceService } from "../../../services/invoice.service";
+import { type Invoice } from "../../../types/invoice.type";
+import { InvoiceEditorComponent } from "../invoice-editor/invoice-editor";
+
+@Component({
+  selector: "app-invoice-lister",
+  imports: [CommonModule, ReactiveFormsModule, InvoiceEditorComponent],
+  templateUrl: "./invoice-lister.html",
+  styles: ``,
+})
+export class InvoiceListerComponent implements OnInit {
+  private destroyRef = inject(DestroyRef);
+  private toast = inject(Toast);
+  private invoiceService = inject(InvoiceService);
+  loading = signal(false);
+
+  filterForm = new FormGroup({
+    criteria: new FormControl("", Validators.required),
+  });
+
+  allInvoice = signal<Invoice[]>([]);
+  afterCreateInvoice(newInvoice: Invoice) {
+    this.allInvoice.update((allInvoice) => {
+      return [newInvoice, ...allInvoice];
+    });
+  }
+  afterUpdateInvoice(newInvoice: Invoice) {
+    this.allInvoice.update((allInvoice) => {
+      return allInvoice.map((invoice) =>
+        invoice.id === newInvoice.id ? newInvoice : invoice
+      );
+    });
+  }
+  afterRemoveInvoice(newInvoice: Invoice) {
+    this.allInvoice.update((allInvoice) => {
+      return allInvoice.filter((invoice) => invoice.id !== newInvoice.id);
+    });
+  }
+
+  newInvoice = computed<Invoice>(() => {
+    const today = new Date().toISOString().substring(0, 10);
+    return {
+      version: 0,
+      issued: today,
+      period: "PT0S",
+      status: "D",
+      text: "",
+    };
+  });
+
+  ngOnInit() {
+    // No extra data to load
+  }
+
+  constructor() {
+    effect(() => this.onFilterClicked());
+  }
+
+  onFilterClicked() {
+    this.loading.set(true);
+    const search = {
+      sort: "issued,desc",
+      ...(this.filterForm.value.criteria
+        ? { text: "%" + this.filterForm.value.criteria + "%" }
+        : {}),
+    };
+    const subscription = this.invoiceService.loadAllInvoice(search).subscribe({
+      next: (allInvoice) => {
+        this.allInvoice.set(allInvoice);
+      },
+      complete: () => {
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.toast.push(err);
+      },
+    });
+    this.destroyRef.onDestroy(() => {
+      subscription.unsubscribe();
+    });
+  }
+
+  invoiceId = signal<string | undefined>(undefined); // no invoice selected
+  onInvoiceClicked(invoice: Invoice) {
+    this.invoiceId.set(invoice.id);
+  }
+
+  invoiceEditorCreate = signal(false);
+  onInvoiceEditorCreateClicked() {
+    this.invoiceId.set(undefined); // no invoice selected
+    this.invoiceEditorCreate.set(true);
+    this.invoiceEditorUpdate.set(false);
+  }
+
+  invoiceEditorUpdate = signal(false);
+  onInvoiceEditorUpdateClicked(invoice: Invoice) {
+    this.invoiceId.set(invoice.id);
+    this.invoiceEditorCreate.set(false);
+    this.invoiceEditorUpdate.set(true);
+  }
+
+  readonly invoiceFilterDisabled = computed(
+    () => this.invoiceEditorCreate() || this.invoiceEditorUpdate()
+  );
+
+  readonly invoiceEditorDisabled = computed(() => this.invoiceFilterDisabled());
+
+  onInvoiceRemoveClicked(invoice: Invoice) {
+    this.invoiceId.set(undefined); // no invoice selected
+    const hint = invoice.issued;
+    if (!confirm("Delete invoice '" + hint + "' permanently?")) return;
+    this.loading.set(true);
+    const subscription = this.invoiceService
+      .removeInvoice(invoice.id!)
+      .subscribe({
+        next: (invoice) => {
+          this.afterRemoveInvoice(invoice);
+        },
+        complete: () => {
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.toast.push(err);
+        },
+      });
+    this.destroyRef.onDestroy(() => {
+      subscription.unsubscribe();
+    });
+  }
+}

--- a/app/client-angular/src/main/angular/pages/clinic/invoice.routes.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/invoice.routes.ts
@@ -1,0 +1,12 @@
+import { Routes } from "@angular/router";
+import { InvoiceService } from "../../services/invoice.service";
+import { VisitService } from "../../services/visit.service";
+import { InvoiceListerComponent } from "./invoice-lister/invoice-lister";
+
+export const routes: Routes = [
+  {
+    path: "",
+    component: InvoiceListerComponent,
+    providers: [InvoiceService, VisitService],
+  },
+];

--- a/app/client-angular/src/main/angular/services/backend.service.ts
+++ b/app/client-angular/src/main/angular/services/backend.service.ts
@@ -113,4 +113,28 @@ export abstract class BackendService {
     );
   }
   // end::restApiDelete[]
+
+  // tag::graphqlQuery[]
+  protected graphqlQuery<T>(query: string): Observable<T> {
+    const url = new URL("api/graphql", this.backendUrl());
+    const reqBody = { query };
+    return this.httpClient
+      .post<{
+        data?: T;
+        errors?: { message: string }[];
+      }>(url.toString(), reqBody)
+      .pipe(
+        catchError(this.handleError(url)),
+        map((resBody) => {
+          if (resBody.errors?.length) {
+            throw { detail: resBody.errors[0].message } as any;
+          }
+          return resBody.data as T;
+        }),
+        tap((resBody) => {
+          console.log([["POST", url].join(" "), query, resBody]);
+        })
+      );
+  }
+  // end::graphqlQuery[]
 }

--- a/app/client-angular/src/main/angular/services/invoice.service.ts
+++ b/app/client-angular/src/main/angular/services/invoice.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@angular/core";
+import { HttpClient } from "@angular/common/http";
+import { Observable } from "rxjs";
+import { type Invoice } from "../types/invoice.type";
+import { BackendService } from "./backend.service";
+
+@Injectable()
+export class InvoiceService extends BackendService {
+  constructor(httpClient: HttpClient) {
+    super(httpClient);
+  }
+
+  public loadAllInvoice(
+    search: Record<string, string> = {}
+  ): Observable<Invoice[]> {
+    const path = ["api", "invoice"].join("/");
+    return this.restApiGetAll(path, search);
+  }
+
+  public loadOneInvoice(id: string): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiGet(path);
+  }
+
+  public createInvoice(value: Invoice): Observable<Invoice> {
+    const path = ["api", "invoice"].join("/");
+    return this.restApiPost(path, value);
+  }
+
+  public mutateInvoice(
+    id: string,
+    value: Partial<Invoice>
+  ): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiPatch(path, value);
+  }
+
+  public removeInvoice(id: string): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiDelete(path);
+  }
+}

--- a/app/client-angular/src/main/angular/services/visit.service.ts
+++ b/app/client-angular/src/main/angular/services/visit.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
-import { Observable } from "rxjs";
-import { type Visit } from "../types/visit.type";
+import { Observable, map } from "rxjs";
+import { type Visit, type VisitItem } from "../types/visit.type";
 import { BackendService } from "./backend.service";
 
 @Injectable()
@@ -35,5 +35,17 @@ export class VisitService extends BackendService {
   public removeVisit(id: string): Observable<Visit> {
     const path = ["api", "visit", id].join("/");
     return this.restApiDelete(path);
+  }
+
+  public loadAllVisitByText(text: string): Observable<VisitItem[]> {
+    const query = `{ allVisitByText(text: ${JSON.stringify(text)}) { id date pet { name owner { name address } } } }`;
+    return this.graphqlQuery<{ allVisitByText: any[] }>(query).pipe(
+      map((data) =>
+        data.allVisitByText.map((v) => ({
+          value: v.id,
+          text: `${v.pet?.name} of ${v.pet?.owner?.name}, ${v.pet?.owner?.address} at ${v.date}`,
+        }))
+      )
+    );
   }
 }

--- a/app/client-angular/src/main/angular/types/invoice.type.ts
+++ b/app/client-angular/src/main/angular/types/invoice.type.ts
@@ -1,0 +1,11 @@
+export type InvoiceStatus = "D" | "I" | "C" | "X";
+
+export interface Invoice {
+  id?: string;
+  version: number;
+  issued: string;
+  period: string;
+  status: InvoiceStatus;
+  text: string;
+  visit?: string | null;
+}

--- a/app/client-angular/src/main/angular/types/visit.type.ts
+++ b/app/client-angular/src/main/angular/types/visit.type.ts
@@ -2,6 +2,11 @@ import { OwnerItem } from "./owner.type";
 import { PetItem } from "./pet.type";
 import { VetItem } from "./vet.type";
 
+export interface VisitItem {
+  value: string;
+  text: string;
+}
+
 export interface Visit {
   id?: string;
   version: number;

--- a/app/client-svelte/src/main/svelte/App.svelte
+++ b/app/client-svelte/src/main/svelte/App.svelte
@@ -11,6 +11,7 @@
   import OwnerViewer from "./pages/client/OwnerViewer.svelte";
   import PetLister from "./pages/client/PetLister.svelte";
   import PetViewer from "./pages/client/PetViewer.svelte";
+  import InvoiceLister from "./pages/clinic/InvoiceLister.svelte";
   import VetLister from "./pages/clinic/VetLister.svelte";
   import VetViewer from "./pages/clinic/VetViewer.svelte";
   import VisitLister from "./pages/clinic/VisitLister.svelte";
@@ -86,6 +87,10 @@
             <span class="capitalize">Clinic</span>
             <ul class="p-2">
               <li>
+                <a class="link" onclick={onMenuClose} href="/invoice">Invoice</a
+                >
+              </li>
+              <li>
                 <a class="link" onclick={onMenuClose} href="/visit">Visit</a>
               </li>
               <li>
@@ -126,6 +131,7 @@
       <Route path="/owner/:id" component={OwnerViewer} />
       <Route path="/pet" component={PetLister} />
       <Route path="/pet/:id" component={PetViewer} />
+      <Route path="/invoice" component={InvoiceLister} />
       <Route path="/visit" component={VisitLister} />
       <Route path="/visit/:id" component={VisitViewer} />
       <Route path="/vet" component={VetLister} />

--- a/app/client-svelte/src/main/svelte/pages/clinic/InvoiceEditor.svelte
+++ b/app/client-svelte/src/main/svelte/pages/clinic/InvoiceEditor.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+  import { onMount, onDestroy } from "svelte";
+  import { Subject, debounceTime, distinctUntilChanged, switchMap } from "rxjs";
+  import { toast } from "../../controls/Toast";
+  import { InvoiceService } from "../../services/invoice.service";
+  import { VisitService } from "../../services/visit.service";
+  import type { VisitItem } from "../../types/visit.type";
+  import type { Invoice, InvoiceStatus } from "../../types/invoice.type";
+
+  const invoiceService = new InvoiceService();
+  const visitService = new VisitService();
+
+  interface Props {
+    autofocus?: boolean;
+    autoscroll?: boolean;
+    visible: boolean;
+    invoice: Invoice;
+    oncancel?: undefined | (() => void);
+    oncreate?: undefined | ((invoice: Invoice) => void);
+    onupdate?: undefined | ((invoice: Invoice) => void);
+  }
+
+  let {
+    autofocus = true,
+    autoscroll = true,
+    visible = $bindable(false),
+    invoice = {} as Invoice,
+    oncancel = undefined,
+    oncreate = undefined,
+    onupdate = undefined,
+  }: Props = $props();
+
+  let clicked = $state(false);
+  let focusOn: any;
+  let bottomDiv: HTMLElement;
+
+  // Visit picker
+  let visitFilter = $state("");
+  let allVisitItem = $state([] as VisitItem[]);
+  let selectedVisitId = $state("");
+
+  const visitFilter$ = new Subject<string>();
+  const visitSub = visitFilter$
+    .pipe(
+      debounceTime(300),
+      distinctUntilChanged(),
+      switchMap((text) => visitService.loadAllVisitByText(text))
+    )
+    .subscribe({
+      next: (items) => {
+        allVisitItem = items;
+      },
+      error: (err) => {
+        toast.push(err);
+      },
+    });
+
+  onMount(async () => {
+    if (autofocus) focusOn.focus();
+    if (autoscroll) bottomDiv.scrollIntoView(false);
+  });
+
+  onDestroy(() => {
+    visitSub.unsubscribe();
+    visitFilter$.complete();
+  });
+
+  function onVisitFilterInput(event: Event) {
+    const text = (event.target as HTMLInputElement).value;
+    visitFilter = text;
+    visitKeyIndex = -1;
+    if (text.length >= 2) {
+      visitFilter$.next(text);
+    } else {
+      allVisitItem = [];
+    }
+  }
+
+  let visitKeyIndex = $state(-1);
+
+  function onVisitKeyDown(event: KeyboardEvent) {
+    if (!allVisitItem.length) return;
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      visitKeyIndex = Math.min(visitKeyIndex + 1, allVisitItem.length - 1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      visitKeyIndex = Math.max(visitKeyIndex - 1, 0);
+    } else if (event.key === "Enter") {
+      event.preventDefault();
+      if (visitKeyIndex >= 0) selectVisitItem(allVisitItem[visitKeyIndex]);
+    } else if (event.key === "Escape" || event.key === "Tab") {
+      allVisitItem = [];
+      visitKeyIndex = -1;
+    }
+  }
+
+  function selectVisitItem(item: (typeof allVisitItem)[0]) {
+    selectedVisitId = item.value;
+    visitFilter = item.text;
+    allVisitItem = [];
+    visitKeyIndex = -1;
+  }
+
+  function parseDays(iso: string): number {
+    const match = /PT(\d+)H/.exec(iso ?? "");
+    const hours = match?.[1] ? parseInt(match[1], 10) : 0;
+    return Math.round(hours / 24);
+  }
+
+  function buildPeriod(days: number): string {
+    if (days === 0) return "PT0S";
+    return `PT${days * 24}H`;
+  }
+
+  let newIssued = $state("");
+  let newDays = $state(0);
+  let newStatus = $state("D" as InvoiceStatus);
+  let newText = $state("");
+
+  $effect(() => {
+    newIssued = invoice.issued ?? "";
+    newDays = parseDays(invoice.period);
+    newStatus = invoice.status ?? "D";
+    newText = invoice.text ?? "";
+    selectedVisitId = invoice.visit?.replace("/api/visit/", "") ?? "";
+  });
+
+  const newInvoice = $derived({
+    ...invoice,
+    issued: newIssued,
+    period: buildPeriod(newDays),
+    status: newStatus,
+    text: newText,
+    visit: selectedVisitId ? `/api/visit/${selectedVisitId}` : invoice.visit,
+  });
+
+  function onSubmitClicked(_event: Event) {
+    _event.preventDefault();
+    try {
+      clicked = true;
+      if (invoice.id) {
+        invoiceService.mutateInvoice(invoice.id, newInvoice).subscribe({
+          next: (json) => {
+            visible = false;
+            onupdate?.(json);
+          },
+          error: (err) => {
+            toast.push(err);
+          },
+        });
+      } else {
+        invoiceService.createInvoice(newInvoice).subscribe({
+          next: (json) => {
+            visible = false;
+            oncreate?.(json);
+          },
+          error: (err) => {
+            toast.push(err);
+          },
+        });
+      }
+    } finally {
+      clicked = false;
+    }
+  }
+
+  function onCancelClicked(_event: Event) {
+    _event.preventDefault();
+    visible = false;
+    oncancel?.();
+  }
+</script>
+
+<form onsubmit={onSubmitClicked}>
+  <div class="flex flex-col gap-2 pt-4">
+    <div class="flex flex-col gap-2 sm:flex-row">
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Issue Date</legend>
+        <input
+          bind:this={focusOn}
+          bind:value={newIssued}
+          aria-label="Issue Date"
+          type="date"
+          class="input input-bordered w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Payment period in days</legend>
+        <input
+          bind:value={newDays}
+          aria-label="Payment period in days"
+          type="number"
+          min="0"
+          class="input input-bordered w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Status</legend>
+        <select
+          bind:value={newStatus}
+          aria-label="Status"
+          class="select w-full"
+        >
+          <option value="D">drafted</option>
+          <option value="I">issued</option>
+          <option value="C">completed</option>
+          <option value="X">cancelled</option>
+        </select>
+      </fieldset>
+    </div>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Visit</legend>
+      <div class="relative">
+        <input
+          value={visitFilter}
+          oninput={onVisitFilterInput}
+          onfocus={onVisitFilterInput}
+          onkeydown={onVisitKeyDown}
+          aria-label="Filter visits"
+          aria-autocomplete="list"
+          type="text"
+          class="input input-bordered w-full"
+          placeholder="Type to search visits…"
+          autocomplete="off"
+        />
+        {#if allVisitItem.length > 0}
+          <ul
+            class="absolute z-10 w-full bg-base-100 border border-base-300 rounded-box shadow-lg mt-1 max-h-60 overflow-y-auto"
+            role="listbox"
+          >
+            {#each allVisitItem as item, i}
+              <li
+                role="option"
+                aria-selected={selectedVisitId === item.value}
+                class="px-3 py-2 cursor-pointer"
+                class:bg-primary={i === visitKeyIndex}
+                class:text-primary-content={i === visitKeyIndex}
+                class:hover:bg-base-200={i !== visitKeyIndex}
+                onmousedown={() => selectVisitItem(item)}
+              >
+                {item.text}
+              </li>
+            {/each}
+          </ul>
+        {/if}
+      </div>
+    </fieldset>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Text</legend>
+      <textarea
+        bind:value={newText}
+        aria-label="Text"
+        class="textarea w-full"
+        placeholder="Enter invoice description"
+      ></textarea>
+    </fieldset>
+  </div>
+  <div class="join py-4">
+    <button type="submit" class="btn join-item" disabled={clicked}>Ok</button>
+    <button type="button" class="btn join-item" onclick={onCancelClicked}>
+      Cancel
+    </button>
+  </div>
+</form>
+
+<div class="h-0" bind:this={bottomDiv}>&nbsp;</div>
+
+{#if import.meta.env.DEV}
+  <details tabindex="-1">
+    <summary>JSON</summary>
+    <pre>{JSON.stringify(newInvoice, null, 2)}</pre>
+  </details>
+{/if}

--- a/app/client-svelte/src/main/svelte/pages/clinic/InvoiceLister.svelte
+++ b/app/client-svelte/src/main/svelte/pages/clinic/InvoiceLister.svelte
@@ -1,0 +1,224 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { toast } from "../../controls/Toast";
+  import { InvoiceService } from "../../services/invoice.service";
+  import type { Invoice } from "../../types/invoice.type";
+  import InvoiceEditor from "./InvoiceEditor.svelte";
+
+  const invoiceService = new InvoiceService();
+
+  let loading = $state(true);
+  onMount(async () => {
+    try {
+      loading = true;
+      loadAllInvoice();
+    } finally {
+      loading = false;
+    }
+  });
+
+  let invoiceId = $state("");
+  function onInvoiceClicked(_invoice: Invoice) {
+    invoiceId = _invoice.id!;
+  }
+  function onInvoiceRemoveClicked(_invoice: Invoice) {
+    invoiceId = _invoice.id!;
+    removeInvoice(_invoice);
+  }
+
+  let invoiceEditorCreate = $state(false);
+  function onInvoiceEditorCreateClicked() {
+    invoiceId = "";
+    invoiceEditorCreate = true;
+    invoiceEditorUpdate = false;
+  }
+
+  let invoiceEditorUpdate = $state(false);
+  function onInvoiceEditorUpdateClicked(_invoice: Invoice) {
+    invoiceId = _invoice.id!;
+    invoiceEditorUpdate = true;
+    invoiceEditorCreate = false;
+  }
+
+  const invoiceFilterDisabled = $derived(
+    invoiceEditorCreate || invoiceEditorUpdate
+  );
+
+  const invoiceEditorDisabled = $derived(invoiceFilterDisabled);
+
+  let allInvoice: Invoice[] = $state([]);
+  function afterCreateInvoice(_invoice: Invoice) {
+    allInvoice = [_invoice, ...allInvoice];
+  }
+  function afterUpdateInvoice(_invoice: Invoice) {
+    allInvoice = allInvoice.map((e) => (e.id === _invoice.id ? _invoice : e));
+  }
+  function afterRemoveInvoice(_invoice: Invoice) {
+    allInvoice = allInvoice.filter((e) => e.id !== _invoice.id);
+  }
+
+  let invoiceFilter = $state("");
+  function onFilterClicked(_event: Event) {
+    _event.preventDefault();
+    try {
+      loading = true;
+      loadAllInvoice();
+    } finally {
+      loading = false;
+    }
+  }
+
+  function loadAllInvoice() {
+    const search = {
+      sort: "issued,desc",
+      ...(invoiceFilter ? { text: "%" + invoiceFilter + "%" } : {}),
+    };
+    invoiceService.loadAllInvoice(search).subscribe({
+      next: (json) => {
+        allInvoice = json;
+      },
+      error: (err) => {
+        toast.push(err);
+      },
+    });
+  }
+
+  function removeInvoice(_invoice: Invoice) {
+    const hint = _invoice.issued;
+    if (!confirm("Delete invoice '" + hint + "' permanently?")) return;
+    invoiceService.removeInvoice(_invoice.id!).subscribe({
+      next: (json) => {
+        afterRemoveInvoice(json);
+      },
+      error: (err) => {
+        toast.push(err);
+      },
+    });
+  }
+
+  const today = new Date().toISOString().substring(0, 10);
+  const newInvoice = $derived<Invoice>({
+    version: 0,
+    issued: today,
+    period: "PT0S",
+    status: "D",
+    text: "",
+  });
+</script>
+
+<h1>Invoice</h1>
+
+<div class="flex flex-col gap-1 ml-2 mr-2">
+  <form onsubmit={onFilterClicked}>
+    <div class="flex flex-row gap-2 items-center pb-2 pr-2">
+      <input
+        bind:value={invoiceFilter}
+        aria-label="Filter"
+        type="text"
+        class="input input-bordered w-full"
+        readonly={invoiceFilterDisabled}
+        placeholder="Enter filter criteria"
+      />
+      <button
+        type="submit"
+        title="Filter items"
+        class="btn btn-circle btn-outline"
+        disabled={invoiceFilterDisabled}
+      >
+        <span class="material-icons">search</span>
+      </button>
+    </div>
+  </form>
+  {#if loading}
+    <div class="h-screen flex justify-center items-start">
+      <span class="loading loading-spinner loading-xl"></span>
+    </div>
+  {:else}
+    <table class="table-fixed">
+      <thead class="justify-between">
+        <tr class="bg-gray-200">
+          <th class="px-2 py-3 text-left w-1/4 table-cell">
+            <span class="text-gray-600">Issue Date</span>
+          </th>
+          <th class="px-2 py-3 text-left w-full table-cell">
+            <span class="text-gray-600">Text</span>
+          </th>
+          <th class="px-2 py-3 text-right w-16 table-cell">
+            <button
+              title="Add a new invoice"
+              class="btn btn-circle btn-outline"
+              onclick={onInvoiceEditorCreateClicked}
+              disabled={invoiceEditorDisabled}
+            >
+              <span class="material-icons">add</span>
+            </button>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {#if invoiceEditorCreate}
+          <tr>
+            <td class="border-l-4 px-2" colspan="3">
+              <InvoiceEditor
+                oncreate={afterCreateInvoice}
+                bind:visible={invoiceEditorCreate}
+                invoice={newInvoice}
+              />
+            </td>
+          </tr>
+        {/if}
+        {#each allInvoice as invoice}
+          <tr
+            onclick={() => onInvoiceClicked(invoice)}
+            title={invoice.issued}
+            class:border-l-2={invoiceId === invoice.id}
+          >
+            <td class="px-2 py-3 text-left table-cell">
+              {invoice.issued}
+            </td>
+            <td class="px-2 py-3 text-left table-cell">
+              {invoice.text}
+            </td>
+            <td class="px-2 py-3 table-cell">
+              <div
+                class="grid grid-cols-1 md:grid-cols-2 items-center gap-1 w-max"
+              >
+                <button
+                  title="Delete an invoice"
+                  class="btn btn-circle btn-outline"
+                  onclick={() => onInvoiceRemoveClicked(invoice)}
+                  disabled={invoiceEditorDisabled}
+                >
+                  <span class="material-icons">delete</span>
+                </button>
+                <button
+                  title="Edit an invoice"
+                  class="btn btn-circle btn-outline"
+                  onclick={() => onInvoiceEditorUpdateClicked(invoice)}
+                  disabled={invoiceEditorDisabled}
+                >
+                  <span class="material-icons">edit</span>
+                </button>
+              </div>
+            </td>
+          </tr>
+          {#if invoiceEditorUpdate && invoiceId === invoice.id}
+            <tr>
+              <td class="border-l-4 px-2" colspan="3">
+                <InvoiceEditor
+                  onupdate={afterUpdateInvoice}
+                  bind:visible={invoiceEditorUpdate}
+                  {invoice}
+                />
+              </td>
+            </tr>
+          {/if}
+        {:else}
+          <tr>
+            <td class="px-2" colspan="3">No invoices</td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</div>

--- a/app/client-svelte/src/main/svelte/services/backend.service.ts
+++ b/app/client-svelte/src/main/svelte/services/backend.service.ts
@@ -172,4 +172,36 @@ export abstract class BackendService {
     );
   }
   // end::restApiDelete[]
+
+  // tag::graphqlQuery[]
+  protected graphqlQuery<T>(query: string): Observable<T> {
+    const url = new URL("api/graphql", this.backendUrl());
+    const reqBody = JSON.stringify({ query });
+    return from(
+      fetch(url.toString(), {
+        mode: "cors",
+        method: "POST",
+        headers: {
+          Accept: "application/json",
+          "Content-type": "application/json",
+        },
+        body: reqBody,
+      })
+    ).pipe(
+      catchError((err) => this.handleError(url, err)),
+      switchMap((res) =>
+        this.handleResponse<{ data?: T; errors?: { message: string }[] }>(res)
+      ),
+      map((resBody) => {
+        if (resBody.errors?.length) {
+          throw { detail: resBody.errors[0].message } as any;
+        }
+        return resBody.data as T;
+      }),
+      tap((resBody) => {
+        console.log([["POST", url].join(" "), query, resBody]);
+      })
+    );
+  }
+  // end::graphqlQuery[]
 }

--- a/app/client-svelte/src/main/svelte/services/invoice.service.test.ts
+++ b/app/client-svelte/src/main/svelte/services/invoice.service.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { InvoiceService } from "./invoice.service";
+import type { Invoice } from "../types/invoice.type";
+
+const ALLINVOICE: Invoice[] = [
+  {
+    id: "1",
+    version: 1,
+    issued: "2024-01-15",
+    period: "PT720H",
+    status: "D",
+    text: "Lorem ipsum.",
+  },
+  {
+    id: "2",
+    version: 1,
+    issued: "2024-03-01",
+    period: "PT360H",
+    status: "I",
+    text: "Dolor sit amet.",
+  },
+];
+
+describe("InvoiceService", () => {
+  let invoiceService: InvoiceService;
+  let fetchMock: any;
+
+  beforeEach(() => {
+    global.window = {
+      location: {
+        protocol: "http:",
+        host: "localhost:5050",
+      },
+    } as any;
+    fetchMock = vi.fn();
+    global.fetch = fetchMock;
+    invoiceService = new InvoiceService();
+  });
+
+  it("should be created", () => {
+    expect(invoiceService).toBeTruthy();
+  });
+
+  describe("loadAllInvoice", () => {
+    it("should load invoices successfully", () => {
+      const content: Invoice[] = ALLINVOICE;
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ content: content }),
+      });
+      invoiceService.loadAllInvoice().subscribe({
+        next: (allInvoice) => {
+          expect(allInvoice).toEqual(content);
+        },
+      });
+    });
+  });
+
+  describe("loadOneInvoice", () => {
+    it("should load one invoice successfully", () => {
+      const content: Invoice = ALLINVOICE[0];
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => content,
+      });
+      invoiceService.loadOneInvoice(content.id!).subscribe({
+        next: (invoice) => {
+          expect(invoice).toEqual(content);
+        },
+      });
+    });
+  });
+
+  describe("createInvoice", () => {
+    it("should create invoice successfully", () => {
+      const content: Invoice = ALLINVOICE[0];
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => content,
+      });
+      invoiceService.createInvoice(content).subscribe({
+        next: (invoice) => {
+          expect(invoice).toEqual(content);
+        },
+      });
+    });
+  });
+
+  describe("mutateInvoice", () => {
+    it("should mutate invoice successfully", () => {
+      const content: Invoice = ALLINVOICE[0];
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => content,
+      });
+      invoiceService.mutateInvoice(content.id!, content).subscribe({
+        next: (invoice) => {
+          expect(invoice).toEqual(content);
+        },
+      });
+    });
+  });
+
+  describe("removeInvoice", () => {
+    it("should remove invoice successfully", () => {
+      const content: Invoice = ALLINVOICE[0];
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => content,
+      });
+      invoiceService.removeInvoice(content.id!).subscribe({
+        next: (invoice) => {
+          expect(invoice).toEqual(content);
+        },
+      });
+    });
+  });
+});

--- a/app/client-svelte/src/main/svelte/services/invoice.service.ts
+++ b/app/client-svelte/src/main/svelte/services/invoice.service.ts
@@ -1,0 +1,35 @@
+import { Observable } from "rxjs";
+import type { Invoice } from "../types/invoice.type";
+import { BackendService } from "./backend.service";
+
+export class InvoiceService extends BackendService {
+  public loadAllInvoice(
+    search: Record<string, string> = {}
+  ): Observable<Invoice[]> {
+    const path = ["api", "invoice"].join("/");
+    return this.restApiGetAll(path, search);
+  }
+
+  public loadOneInvoice(id: string): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiGet(path);
+  }
+
+  public createInvoice(invoice: Invoice): Observable<Invoice> {
+    const path = ["api", "invoice"].join("/");
+    return this.restApiPost(path, invoice);
+  }
+
+  public mutateInvoice(
+    id: string,
+    patch: Partial<Invoice>
+  ): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiPatch(path, patch);
+  }
+
+  public removeInvoice(id: string): Observable<Invoice> {
+    const path = ["api", "invoice", id].join("/");
+    return this.restApiDelete(path);
+  }
+}

--- a/app/client-svelte/src/main/svelte/services/visit.service.ts
+++ b/app/client-svelte/src/main/svelte/services/visit.service.ts
@@ -1,5 +1,5 @@
-import { Observable } from "rxjs";
-import type { Visit } from "../types/visit.type";
+import { Observable, map } from "rxjs";
+import type { Visit, VisitItem } from "../types/visit.type";
 import { BackendService } from "./backend.service";
 
 export class VisitService extends BackendService {
@@ -28,5 +28,17 @@ export class VisitService extends BackendService {
   public removeVisit(id: string): Observable<Visit> {
     const path = ["api", "visit", id].join("/");
     return this.restApiDelete(path);
+  }
+
+  public loadAllVisitByText(text: string): Observable<VisitItem[]> {
+    const query = `{ allVisitByText(text: ${JSON.stringify(text)}) { id date pet { name owner { name address } } } }`;
+    return this.graphqlQuery<{ allVisitByText: any[] }>(query).pipe(
+      map((data) =>
+        data.allVisitByText.map((v) => ({
+          value: v.id,
+          text: `${v.pet?.name} of ${v.pet?.owner?.name}, ${v.pet?.owner?.address} at ${v.date}`,
+        }))
+      )
+    );
   }
 }

--- a/app/client-svelte/src/main/svelte/types/invoice.type.ts
+++ b/app/client-svelte/src/main/svelte/types/invoice.type.ts
@@ -1,0 +1,11 @@
+export type InvoiceStatus = "D" | "I" | "C" | "X";
+
+export interface Invoice {
+  id?: string;
+  version: number;
+  issued: string;
+  period: string;
+  status: InvoiceStatus;
+  text: string;
+  visit?: string | null;
+}

--- a/app/client-svelte/src/main/svelte/types/visit.type.ts
+++ b/app/client-svelte/src/main/svelte/types/visit.type.ts
@@ -2,6 +2,11 @@ import type { OwnerItem } from "./owner.type";
 import type { PetItem } from "./pet.type";
 import type { VetItem } from "./vet.type";
 
+export interface VisitItem {
+  value: string;
+  text: string;
+}
+
 export interface Visit {
   id?: string;
   version: number;

--- a/doc/service/invoice-graphql.adoc
+++ b/doc/service/invoice-graphql.adoc
@@ -1,0 +1,100 @@
+:includedir: ../..
+:relrootdir: ../..
+:graphqldir: {includedir}/lib/backend-data/src/main/resources/graphql
+= Invoice GraphQL API
+
+GraphQL API for querying invoices in the pet clinic application.
+It provides query operations to retrieve all invoices and filter invoices by issue date.
+
+== Model
+
+=== Invoice
+
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Invoice.adoc[]
+
+The schema type `Invoice` defines properties and a relation to `Visit`.
+
+.Schema
+[source,graphql,options="nowrap"]
+----
+include::{graphqldir}/Invoice.gqls[]
+----
+
+The property `issued` uses the custom scalar type `LocalDate` which maps to Java's `java.time.LocalDate` type for representing calendar dates with format `yyyy-MM-dd`.
+
+The property `period` is a String in ISO-8601 Duration format (e.g. `PT720H` for 30 days).
+
+The property `status` uses the enum `InvoiceStatus`.
+
+The relation `visit` uses batch loading via `@BatchMapping` to efficiently load visits for multiple invoices.
+
+=== InvoiceStatus
+
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.adoc[]
+
+.Schema
+[source,graphql,options="nowrap"]
+----
+include::{graphqldir}/InvoiceStatus.gqls[]
+----
+
+== Queries
+
+=== Collection queries
+
+==== `allInvoice`
+
+This query returns all invoices in the system.
+
+.Query Definition
+[source,graphql,options="nowrap"]
+----
+allInvoice: [Invoice]
+----
+
+*Returns:*
+
+A list of all `Invoice` objects.
+Returns an empty list if no invoices exist.
+
+==== `allInvoiceAt`
+
+This query returns all invoices issued on a specific date.
+
+.Query Definition
+[source,graphql,options="nowrap"]
+----
+allInvoiceAt(issued: LocalDate!): [Invoice]
+----
+
+*Arguments:*
+
+`issued` (LocalDate, required)::
+The issue date to filter invoices by (e.g., "2024-01-15").
+
+*Returns:*
+
+A list of `Invoice` objects issued on the specified date, ordered by issue date ascending.
+Returns an empty list if no invoices exist for the given date.
+
+=== Object queries
+
+==== `invoiceById`
+
+This query returns a single invoice by its unique identifier.
+
+.Query Definition
+[source,graphql,options="nowrap"]
+----
+invoiceById(id: ID!): Invoice
+----
+
+*Arguments:*
+
+`id` (ID, required)::
+The unique identifier of the invoice.
+
+*Returns:*
+
+A single `Invoice` object if found.
+Returns `null` if no invoice exists for the given ID.

--- a/doc/service/invoice-restapi.adoc
+++ b/doc/service/invoice-restapi.adoc
@@ -1,0 +1,273 @@
+:includedir: ../..
+:relrootdir: ../..
+:restdocdir: {includedir}/lib/backend-data/build/generated-snippets
+= Invoice REST API
+
+REST-API for managing invoices in the pet clinic application.
+It provides standard CRUD operations and partial updates via PATCH, with filtering capabilities.
+
+== Model
+
+=== Invoice
+
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Invoice.adoc[]
+
+The liquibase script defines the database table.
+
+.Liquibase
+[source,xml,options="nowrap"]
+----
+include::{includedir}/lib/backend-data/src/main/resources/liquibase/v1/invoice.xml[]
+----
+
+The entity class `Invoice` is the aggregate root.
+
+.Entity
+[source,java,options="nowrap"]
+----
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Invoice.java[indent=0,tags=properties]
+----
+
+=== InvoiceStatus
+
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.adoc[]
+
+The enum `InvoiceStatus` defines the lifecycle state of an invoice.
+
+.Enum
+[source,java,options="nowrap"]
+----
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.java[indent=0,tags=enumerations]
+----
+
+=== Visit
+
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Visit.adoc[]
+
+The entity class `Visit` is referenced.
+An invoice is linked to exactly one visit.
+
+.Entity
+[source,java,options="nowrap"]
+----
+include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Visit.java[indent=0,tags=properties]
+----
+
+== Operations
+
+=== `POST /api/invoice`
+
+This operation creates a new _Invoice_ entity.
+
+****
+
+.Command
+include::{restdocdir}/post-api-invoice/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/post-api-invoice/http-request.adoc[]
+
+.Response
+include::{restdocdir}/post-api-invoice/response-body.adoc[]
+
+****
+
+This operation reports `Created` or code 201 if the entity was successfully created.
+
+This operation reports `Bad Request` or code 400 if the data was not processed.
+
+This operation reports `Conflict` or code 409 if a unique constraint would be violated.
+
+=== `PUT /api/invoice/{id}`
+
+This operation updates an existing _Invoice_ entity or creates a new one.
+
+****
+
+.Command
+include::{restdocdir}/put-api-invoice/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/put-api-invoice/http-request.adoc[]
+
+.Response
+include::{restdocdir}/put-api-invoice/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the entity was successfully updated.
+
+This operation reports `Created` or code 201 if the entity was successfully created.
+
+This operation reports `Bad Request` or code 400 if the data was not processed.
+
+This operation reports `Conflict` or code 409 if a unique constraint would be violated.
+
+This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
+
+=== `PATCH /api/invoice/{id}`
+
+This operation partially updates an existing `Invoice` entity without affecting other properties.
+Response is of type `Invoice`.
+
+==== `text` attribute
+
+****
+
+.Command
+include::{restdocdir}/patch-api-invoice-text/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/patch-api-invoice-text/http-request.adoc[]
+
+.Response
+include::{restdocdir}/patch-api-invoice-text/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the entity was successfully updated.
+
+This operation reports `Not Found` or code 404 if the entity does not exist.
+
+This operation reports `Bad Request` or code 400 if the data was not processed.
+
+This operation reports `Conflict` or code 409 if a unique constraint would be violated.
+
+This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
+
+TIP: The descriptions of attributes other than `text` are omitted for simplicity because they are following the same pattern (e.g. `issued`, `period`, `status`).
+
+==== `visit` relation
+
+****
+
+.Command
+include::{restdocdir}/patch-api-invoice-visit/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/patch-api-invoice-visit/http-request.adoc[]
+
+.Response
+include::{restdocdir}/patch-api-invoice-visit/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the entity was successfully updated.
+
+This operation reports `Not Found` or code 404 if the entity does not exist.
+
+This operation reports `Bad Request` or code 400 if the data was not processed.
+
+This operation reports `Conflict` or code 409 if a unique constraint would be violated.
+
+This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
+
+=== `GET /api/invoice`
+
+This operation returns all persisted _Invoice_ entities.
+
+This operation supports advanced query parameters for filtering, e.g.
+
+`?issued=2024-01-15`::
+Find invoices issued on a single date
+`?issued=2024-01-01&issued=2024-01-31`::
+Find invoices issued between dates (inclusive)
+`?issued=2024-01-01&issued=2024-01-15&issued=2024-01-31`::
+Find invoices issued on multiple dates
+`?period=PT720H`::
+Find invoices with a payment period of 30 days
+`?text=Lorem`::
+Find invoices with text containing "Lorem" (case-insensitive)
+`?text=Lorem%`::
+Find invoices with text starting with "Lorem" (case-insensitive)
+
+This operation supports sorting, e.g.
+
+`?sort=issued,asc`::
+Sort invoices by issue date in ascending order
+`?sort=period,desc`::
+Sort invoices by payment period in descending order
+
+This operation supports pagination, e.g.
+
+`?size=10&page=1`::
+Find 10 invoices on page 1
+
+****
+
+.Command
+include::{restdocdir}/get-api-invoice/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/get-api-invoice/http-request.adoc[]
+
+.Response
+include::{restdocdir}/get-api-invoice/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the data was successfully loaded.
+
+=== `GET /api/invoice/{id}`
+
+This operation returns a single persisted _Invoice_ entity.
+
+****
+
+.Command
+include::{restdocdir}/get-api-invoice-by-id/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/get-api-invoice-by-id/http-request.adoc[]
+
+.Response
+include::{restdocdir}/get-api-invoice-by-id/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the data was successfully loaded.
+
+This operation reports `Not Found` or code 404 if the entity does not exist.
+
+=== `GET /api/invoice/{id}/visit`
+
+This operation returns the associated visit for an invoice.
+The response is of type `Visit`.
+
+****
+
+.Command
+include::{restdocdir}/get-api-invoice-visit/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/get-api-invoice-visit/http-request.adoc[]
+
+.Response
+include::{restdocdir}/get-api-invoice-visit/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the data was successfully loaded.
+
+This operation reports `Not Found` or code 404 if the invoice does not exist.
+
+=== `DELETE /api/invoice/{id}`
+
+This operation deletes an existing `Invoice` entity.
+
+****
+
+.Command
+include::{restdocdir}/delete-api-invoice/curl-request.adoc[]
+
+.Request
+include::{restdocdir}/delete-api-invoice/http-request.adoc[]
+
+.Response
+include::{restdocdir}/delete-api-invoice/response-body.adoc[]
+
+****
+
+This operation reports `Ok` or code 200 if the entity was successfully deleted.
+
+This operation reports `Not Found` or code 404 if the entity does not exist.

--- a/lib/backend-api/src/main/java/esy/api/clinic/Invoice.adoc
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Invoice.adoc
@@ -1,0 +1,6 @@
+An `Invoice` entity represents a billing document issued to a client.
+The `issued` date is required and represents when the invoice was issued.
+The `period` is required and represents the payment period as an duration.
+The `status` indicates the current lifecycle state of the invoice.
+The `text` is required and provides a description or notes for the invoice.
+The `visit` relation is required because every invoice is issued for a specific visit.

--- a/lib/backend-api/src/main/java/esy/api/clinic/Invoice.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Invoice.java
@@ -1,0 +1,137 @@
+package esy.api.clinic;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import esy.jpa.DurationConverter;
+import esy.rest.JsonJpaEntity;
+import esy.rest.JsonJpaMapper;
+import lombok.Getter;
+import lombok.NonNull;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "invoice", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"id"}),
+        @UniqueConstraint(columnNames = {"visit_id"})
+})
+public final class Invoice extends JsonJpaEntity<Invoice> {
+
+    public static final String DATE_PATTERN = "yyyy-MM-dd";
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_PATTERN);
+
+    // tag::properties[]
+    @NotNull
+    @Column(name = "issued", columnDefinition = "DATE")
+    @Getter
+    @JsonProperty
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DATE_PATTERN)
+    private LocalDate issued;
+
+    @NotNull
+    @Column(name = "period", columnDefinition = "BIGINT")
+    @Getter
+    @JsonProperty
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Convert(converter = DurationConverter.class)
+    private Duration period;
+
+    @NotNull
+    @Column(name = "status")
+    @Getter
+    @JsonProperty
+    @Enumerated(EnumType.STRING)
+    private InvoiceStatus status;
+
+    @NotBlank
+    @Column(name = "text")
+    @Getter
+    @JsonProperty
+    private String text;
+
+    @OneToOne(
+            fetch = FetchType.LAZY,
+            optional = false)
+    @JoinColumn(
+            name = "visit_id",
+            referencedColumnName = "id")
+    @Getter
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private Visit visit;
+    // end::properties[]
+
+    Invoice() {
+        super();
+        this.issued = LocalDate.of(2000, 1, 1);
+        this.period = Duration.ZERO;
+        this.status = InvoiceStatus.D;
+        this.text = "";
+        this.visit = null;
+    }
+
+    Invoice(@NonNull final Long version, @NonNull final UUID id) {
+        super(version, id);
+        this.issued = LocalDate.of(2000, 1, 1);
+        this.period = Duration.ZERO;
+        this.status = InvoiceStatus.D;
+        this.text = "";
+        this.visit = null;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + ",issued='" + issued + "'";
+    }
+
+    @Override
+    public boolean isEqual(final Invoice that) {
+        if (this == that) {
+            return true;
+        }
+        if (that == null) {
+            return false;
+        }
+        return Objects.equals(this.issued, that.issued) &&
+                Objects.equals(this.period, that.period) &&
+                Objects.equals(this.status, that.status) &&
+                Objects.equals(this.text, that.text) &&
+                Objects.equals(this.visit, that.visit);
+    }
+
+    @Override
+    public Invoice withId(@NonNull final UUID id) {
+        if (Objects.equals(getId(), id)) {
+            return this;
+        }
+        final var value = new Invoice(getVersion(), id);
+        value.issued = this.issued;
+        value.period = this.period;
+        value.status = this.status;
+        value.text = this.text;
+        value.visit = this.visit;
+        return value;
+    }
+
+    @Override
+    public String writeJson() {
+        return new JsonJpaMapper().writeJson(this);
+    }
+
+    @JsonIgnore
+    public Invoice setVisit(@NonNull final Visit visit) {
+        this.visit = visit;
+        return this;
+    }
+
+    public static Invoice fromJson(@NonNull final String json) {
+        return new JsonJpaMapper().parseJson(json, Invoice.class);
+    }
+}

--- a/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.adoc
+++ b/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.adoc
@@ -1,0 +1,2 @@
+The `InvoiceStatus` enum represents the lifecycle status of an invoice in the clinic.
+The value `D` represents drafted, `I` represents issued, `C` represents completed, and `X` represents cancelled.

--- a/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.java
@@ -1,0 +1,19 @@
+package esy.api.clinic;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.Accessors;
+
+@RequiredArgsConstructor
+public enum InvoiceStatus {
+    // tag::enumerations[]
+    D("drafted"),
+    I("issued"),
+    C("completed"),
+    X("cancelled");
+    // end::enumerations[]
+
+    @Getter
+    @Accessors(fluent = true)
+    private final String text;
+}

--- a/lib/backend-api/src/test/java/esy/api/clinic/InvoiceStatusTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/InvoiceStatusTest.java
@@ -1,0 +1,18 @@
+package esy.api.clinic;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Tag("fast")
+class InvoiceStatusTest {
+
+    @Test
+    void text() {
+        assertEquals("drafted", InvoiceStatus.D.text());
+        assertEquals("issued", InvoiceStatus.I.text());
+        assertEquals("completed", InvoiceStatus.C.text());
+        assertEquals("cancelled", InvoiceStatus.X.text());
+    }
+}

--- a/lib/backend-api/src/test/java/esy/api/clinic/InvoiceTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/InvoiceTest.java
@@ -1,0 +1,255 @@
+package esy.api.clinic;
+
+import esy.rest.JsonJpaMapper;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("fast")
+class InvoiceTest {
+
+    Visit createVisit() {
+        return Visit.fromJson("""
+                {
+                    "id":"deadbeef-dead-beef-dead-deadbeefdead",
+                    "date":"2024-01-10",
+                    "text":"Treatment"
+                }
+                """);
+    }
+
+    Invoice createWithText(final String text) {
+        return Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(text))
+                .setVisit(createVisit());
+    }
+
+    @Test
+    void equalsHashcodeToString() {
+        final var text = "Lorem Ipsum.";
+        final var value = createWithText(text);
+        // Identisches Objekt
+        assertEquals(value, value);
+        assertTrue(value.isEqual(value));
+        assertEquals(value.hashCode(), value.hashCode());
+        assertEquals(value.toString(), value.toString());
+        // Gleiches Objekt
+        final var clone = createWithText(text);
+        assertNotSame(value, clone);
+        assertNotEquals(clone, value);
+        assertTrue(value.isEqual(clone));
+        assertNotEquals(clone.hashCode(), value.hashCode());
+        assertNotEquals(clone.toString(), value.toString());
+        // Anderes Objekt
+        final var other = createWithText("Ex " + text);
+        assertNotSame(value, other);
+        assertNotEquals(other, value);
+        assertFalse(value.isEqual(other));
+        assertNotEquals(other.hashCode(), value.hashCode());
+        assertNotEquals(other.toString(), value.toString());
+        // Kein Objekt
+        assertNotEquals(value, null);
+        assertFalse(value.isEqual(null));
+        // Falsches Objekt
+        assertNotEquals(this, value);
+    }
+
+    @Test
+    void writeJson() {
+        final var text = "Lorem Ipsum.";
+        final var value = createWithText(text);
+        final var json = new JsonJpaMapper().parseJsonNode(value.writeJson());
+        assertFalse(json.at("/version").isMissingNode());
+        assertFalse(json.at("/id").isMissingNode());
+        assertFalse(json.at("/issued").isMissingNode());
+        assertFalse(json.at("/period").isMissingNode());
+        assertFalse(json.at("/status").isMissingNode());
+        assertFalse(json.at("/text").isMissingNode());
+        assertTrue(json.at("/visit").isMissingNode());
+    }
+
+    @Test
+    void withId() {
+        final var text = "Lorem Ipsum.";
+        final var value0 = createWithText(text);
+        assertNotNull(value0.getId());
+        assertNotNull(value0.getIssued());
+        assertNotNull(value0.getPeriod());
+        assertNotNull(value0.getStatus());
+        assertNotNull(value0.getText());
+        assertNotNull(value0.getVisit());
+        final var value1 = value0.withId(value0.getId());
+        assertSame(value0, value1);
+        final var value2 = value0.withId(UUID.randomUUID());
+        assertNotSame(value0, value2);
+        assertTrue(value0.isEqual(value2));
+    }
+
+    @Test
+    void jsonText() {
+        final var text = "Lorem Ipsum.";
+        final var value = Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(text));
+        assertDoesNotThrow(value::verify);
+        assertEquals(text, value.getText());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            " ",
+            "\\t",
+            "\\n"
+    })
+    void jsonTextConstraints(final String text) {
+        final var json = """
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(text);
+        assertThrows(IllegalArgumentException.class, () -> Invoice.fromJson(json).verify());
+    }
+
+    @ParameterizedTest
+    @EnumSource(InvoiceStatus.class)
+    void jsonStatus(final InvoiceStatus status) {
+        final var value = Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"%s",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(status.name()));
+        assertDoesNotThrow(value::verify);
+        assertEquals(status, value.getStatus());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "",
+            "DRAFTED"
+    })
+    void jsonStatusConstraints(final String text) {
+        final var json = """
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"%s",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(text);
+        assertThrows(IllegalArgumentException.class, () -> Invoice.fromJson(json).verify());
+    }
+
+    static Stream<LocalDate> jsonIssued() {
+        return Stream.of(
+                LocalDate.of(2024, 1, 1),
+                LocalDate.of(2024, 4, 15),
+                LocalDate.of(2024, 12, 31)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void jsonIssued(final LocalDate date) {
+        final var value = Invoice.fromJson("""
+                {
+                    "issued":"%s",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(Invoice.DATE_FORMATTER.format(date)));
+        assertDoesNotThrow(value::verify);
+        assertEquals(date, value.getIssued());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2024",
+            "2024-04",
+            "2024-04-32"
+    })
+    void jsonIssuedConstraints(final String text) {
+        final var json = """
+                {
+                    "issued":"%s",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(text);
+        assertThrows(IllegalArgumentException.class, () -> Invoice.fromJson(json).verify());
+    }
+
+    static Stream<Duration> jsonPeriod() {
+        return Stream.of(
+                Duration.ZERO,
+                Duration.ofMillis(1),
+                Duration.ofSeconds(1),
+                Duration.ofMinutes(1),
+                Duration.ofHours(1),
+                Duration.ofDays(1),
+                Duration.ofDays(30),
+                Duration.ofDays(365)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void jsonPeriod(final Duration period) {
+        final var value = Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"%s",
+                    "status":"D",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(period));
+        assertDoesNotThrow(value::verify);
+        assertEquals(period, value.getPeriod());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "30",
+            "30 days"
+    })
+    void jsonPeriodConstraints(final String text) {
+        final var json = """
+                {
+                    "issued":"2024-01-15",
+                    "period":"%s",
+                    "status":"D",
+                    "text":"Lorem Ipsum."
+                }
+                """.formatted(text);
+        assertThrows(IllegalArgumentException.class, () -> Invoice.fromJson(json).verify());
+    }
+}

--- a/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
@@ -94,6 +94,8 @@ class VisitTest {
         assertFalse(json.at("/time").isMissingNode());
         assertFalse(json.at("/billable").isMissingNode());
         assertFalse(json.at("/duration").isMissingNode());
+        assertTrue(json.at("/pet").isMissingNode());
+        assertTrue(json.at("/vet").isMissingNode());
     }
 
     @Test

--- a/lib/backend-data/src/main/java/esy/app/clinic/InvoiceGraphqlController.java
+++ b/lib/backend-data/src/main/java/esy/app/clinic/InvoiceGraphqlController.java
@@ -1,0 +1,69 @@
+package esy.app.clinic;
+
+import esy.api.clinic.Invoice;
+import esy.api.clinic.QInvoice;
+import esy.api.clinic.Visit;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.graphql.data.method.annotation.Argument;
+import org.springframework.graphql.data.method.annotation.BatchMapping;
+import org.springframework.graphql.data.method.annotation.QueryMapping;
+import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Mono;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Controller
+@RequiredArgsConstructor
+public class InvoiceGraphqlController {
+
+    private final InvoiceRepository invoiceRepository;
+
+    private final VisitRepository visitRepository;
+
+    @QueryMapping
+    @Transactional
+    public List<Invoice> allInvoice() {
+        return invoiceRepository.findAll();
+    }
+
+    @QueryMapping
+    @Transactional
+    public Optional<Invoice> invoiceById(@Argument @NonNull final UUID id) {
+        return invoiceRepository.findById(id);
+    }
+
+    @QueryMapping
+    @Transactional
+    public List<Invoice> allInvoiceAt(@Argument @NonNull final LocalDate issued) {
+        final var query = QInvoice.invoice.issued.eq(issued);
+        final var order = QInvoice.invoice.issued.asc();
+        final var allInvoice = new ArrayList<Invoice>();
+        invoiceRepository.findAll(query, order).forEach(allInvoice::add);
+        return allInvoice;
+    }
+
+    @BatchMapping
+    @Transactional
+    public Mono<Map<Invoice, Visit>> visit(@NonNull final List<Invoice> allInvoice) {
+        final var allVisitId = allInvoice
+                .stream()
+                .filter(i -> i.getVisit() != null)
+                .map(i -> i.getVisit().getId())
+                .collect(Collectors.toSet());
+        final var visitById = visitRepository.findAllById(allVisitId)
+                .stream()
+                .collect(Collectors.toMap(Visit::getId, v -> v));
+        return Mono.just(allInvoice
+                .stream()
+                .filter(i -> i.getVisit() != null)
+                .collect(Collectors.toMap(i -> i, i -> visitById.get(i.getVisit().getId()))));
+    }
+}

--- a/lib/backend-data/src/main/java/esy/app/clinic/InvoiceRepository.java
+++ b/lib/backend-data/src/main/java/esy/app/clinic/InvoiceRepository.java
@@ -1,0 +1,19 @@
+package esy.app.clinic;
+
+import esy.api.clinic.Invoice;
+import esy.api.clinic.QInvoice;
+import esy.rest.JsonJpaRepository;
+import esy.rest.QuerydslRepository;
+import lombok.NonNull;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+
+@RepositoryRestResource(path = "invoice", collectionResourceRel = "allInvoice")
+public interface InvoiceRepository extends JsonJpaRepository<Invoice>, QuerydslRepository<Invoice, QInvoice> {
+
+    @Override
+    default void customize(@NonNull final QuerydslBindings bindings, @NonNull final QInvoice root) {
+        bindings.bind(String.class).first(this::stringContainsOrLikeIgnoreCaseBinding);
+        bindings.bind(root.issued).all(this::localDateEqBetweenInBinding);
+    }
+}

--- a/lib/backend-data/src/main/java/esy/app/clinic/InvoiceRestController.java
+++ b/lib/backend-data/src/main/java/esy/app/clinic/InvoiceRestController.java
@@ -1,0 +1,22 @@
+package esy.app.clinic;
+
+import esy.api.clinic.Invoice;
+import esy.rest.JsonJpaRestControllerBase;
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.rest.core.annotation.RepositoryEventHandler;
+import org.springframework.data.rest.webmvc.BasePathAwareController;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@RepositoryEventHandler
+@BasePathAwareController
+public class InvoiceRestController extends JsonJpaRestControllerBase<Invoice> {
+
+    @Autowired
+    public InvoiceRestController(
+            @NonNull final ApplicationEventPublisher eventPublisher,
+            @NonNull final TransactionTemplate transactionTemplate) {
+        super(eventPublisher, transactionTemplate);
+    }
+}

--- a/lib/backend-data/src/main/java/esy/app/clinic/VisitGraphqlController.java
+++ b/lib/backend-data/src/main/java/esy/app/clinic/VisitGraphqlController.java
@@ -67,6 +67,18 @@ public class VisitGraphqlController {
         return allVisit;
     }
 
+    @QueryMapping
+    @Transactional
+    public List<Visit> allVisitByText(@Argument @NonNull final String text) {
+        final var query = QVisit.visit.pet.isNotNull()
+                .and(QVisit.visit.pet.name.containsIgnoreCase(text)
+                        .or(QVisit.visit.pet.owner.name.containsIgnoreCase(text)));
+        final var order = QVisit.visit.date.desc();
+        final var allVisit = new ArrayList<Visit>();
+        visitRepository.findAll(query, order).forEach(allVisit::add);
+        return allVisit;
+    }
+
     @BatchMapping
     @Transactional
     public Mono<Map<Visit, Pet>> pet(@NonNull final List<Visit> allVisit) {

--- a/lib/backend-data/src/main/resources/graphql/Invoice.gqls
+++ b/lib/backend-data/src/main/resources/graphql/Invoice.gqls
@@ -1,0 +1,8 @@
+type Invoice {
+    id: ID!
+    issued: LocalDate!
+    period: String!
+    status: InvoiceStatus!
+    text: String!
+    visit: Visit!
+}

--- a/lib/backend-data/src/main/resources/graphql/InvoiceStatus.gqls
+++ b/lib/backend-data/src/main/resources/graphql/InvoiceStatus.gqls
@@ -1,0 +1,6 @@
+enum InvoiceStatus {
+    D
+    I
+    C
+    X
+}

--- a/lib/backend-data/src/main/resources/graphql/Query.gqls
+++ b/lib/backend-data/src/main/resources/graphql/Query.gqls
@@ -14,4 +14,8 @@ type Query {
     allVisitByPetId(id: ID!): [Visit]
     allVisitByVetId(id: ID!): [Visit]
     allVisitAt(date: LocalDate!): [Visit]
+    allVisitByText(text: String!): [Visit]
+    allInvoice: [Invoice]
+    invoiceById(id: ID!): Invoice
+    allInvoiceAt(issued: LocalDate!): [Invoice]
 }

--- a/lib/backend-data/src/main/resources/liquibase/changelog.xml
+++ b/lib/backend-data/src/main/resources/liquibase/changelog.xml
@@ -11,4 +11,5 @@
     <include file="v1/vet_skill.xml" relativeToChangelogFile="true"/>
     <include file="v1/vet_species.xml" relativeToChangelogFile="true"/>
     <include file="v1/visit.xml" relativeToChangelogFile="true"/>
+    <include file="v1/invoice.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/lib/backend-data/src/main/resources/liquibase/v1/invoice.xml
+++ b/lib/backend-data/src/main/resources/liquibase/v1/invoice.xml
@@ -1,0 +1,52 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.1.xsd">
+    <changeSet id="1" author="robert">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="invoice" /></not>
+        </preConditions>
+        <createTable tableName="invoice">
+            <column name="version" type="BIGINT" defaultValue="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="id" type="UUID">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="issued" type="DATE" defaultValueDate="2001-01-01">
+                <constraints nullable="false"/>
+            </column>
+            <column name="period" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(32)" defaultValue="D">
+                <constraints nullable="false"/>
+            </column>
+            <column name="text" type="VARCHAR(512)" defaultValue="">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+    <changeSet id="2" author="robert">
+        <addColumn tableName="invoice">
+            <column name="visit_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+        <addForeignKeyConstraint
+                constraintName="fk_invoice_visit_id"
+                baseTableName="invoice"
+                baseColumnNames="visit_id"
+                referencedTableName="visit"
+                referencedColumnNames="id"
+        />
+    </changeSet>
+    <changeSet id="3" author="robert">
+        <addUniqueConstraint
+                constraintName="uk_invoice"
+                tableName="invoice"
+                columnNames="visit_id"
+        />
+    </changeSet>
+</databaseChangeLog>

--- a/lib/backend-data/src/test/java/esy/app/DatabaseCleaner.java
+++ b/lib/backend-data/src/test/java/esy/app/DatabaseCleaner.java
@@ -20,6 +20,7 @@ public class DatabaseCleaner {
      */
     @Transactional
     public void cleanDatabase() {
+        jdbcTemplate.execute("DELETE FROM invoice");
         jdbcTemplate.execute("DELETE FROM visit");
         jdbcTemplate.execute("DELETE FROM vet_skill");
         jdbcTemplate.execute("DELETE FROM vet_species");

--- a/lib/backend-data/src/test/java/esy/app/clinic/InvoiceGraphqlTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/InvoiceGraphqlTest.java
@@ -1,0 +1,139 @@
+package esy.app.clinic;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import esy.api.clinic.Invoice;
+import esy.api.clinic.Visit;
+import esy.app.EsyGraphqlConfiguration;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.graphql.test.autoconfigure.GraphQlTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.graphql.test.tester.GraphQlTester;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@Tag("fast")
+@GraphQlTest(InvoiceGraphqlController.class)
+@Import(EsyGraphqlConfiguration.class)
+@ExtendWith({MockitoExtension.class})
+class InvoiceGraphqlTest {
+
+    @Autowired
+    private GraphQlTester graphQlTester;
+
+    @MockitoBean
+    private InvoiceRepository invoiceRepository;
+
+    @MockitoBean
+    private VisitRepository visitRepository;
+
+    Invoice createWithText(final String text) {
+        return Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(text));
+    }
+
+    @Test
+    void queryAllInvoice() {
+        final var value = createWithText("Lorem ipsum.");
+        when(invoiceRepository.findAll())
+                .thenReturn(List.of(value));
+        final var data = graphQlTester
+                .document("{allInvoice{text status}}")
+                .execute();
+        assertNotNull(data);
+        data.path("allInvoice[0].text")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(value.getText());
+        data.path("allInvoice[0].status")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(value.getStatus().name());
+        verify(invoiceRepository).findAll();
+        verifyNoMoreInteractions(invoiceRepository);
+        verifyNoInteractions(visitRepository);
+    }
+
+    @Test
+    void queryAllInvoiceWithVisit() {
+        final var visit = Visit.fromJson("""
+                {
+                    "date":"2024-01-10",
+                    "text":"Treatment"
+                }""");
+        final var text = "Ipso facto.";
+        final var value = createWithText(text).setVisit(visit);
+        when(invoiceRepository.findAll())
+                .thenReturn(List.of(value));
+        when(visitRepository.findAllById(any()))
+                .thenReturn(List.of(visit));
+        final var data = graphQlTester
+                .document("{allInvoice{text visit{date}}}")
+                .execute();
+        assertNotNull(data);
+        data.path("allInvoice[0].text")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(text);
+        data.path("allInvoice[0].visit.date")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo("2024-01-10");
+        verify(invoiceRepository).findAll();
+        verifyNoMoreInteractions(invoiceRepository);
+        verify(visitRepository).findAllById(any());
+        verifyNoMoreInteractions(visitRepository);
+    }
+
+    @Test
+    void queryAllInvoiceAt() {
+        final var at = "2024-01-15";
+        final var text = "Lorem tempus.";
+        final var value = Invoice.fromJson("""
+                {
+                    "issued":"%s",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(at, text));
+        when(invoiceRepository.findAll(any(BooleanExpression.class), any(OrderSpecifier.class)))
+                .thenReturn(List.of(value));
+        final var data = graphQlTester
+                .document("""
+                        {allInvoiceAt(issued: "%s"){text}}
+                        """.formatted(at))
+                .execute();
+        assertNotNull(data);
+        data.path("allInvoiceAt[0].text")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(text);
+        final var queryCaptor = ArgumentCaptor.<BooleanExpression>captor();
+        final var orderCaptor = ArgumentCaptor.<OrderSpecifier<LocalDate>>captor();
+        verify(invoiceRepository).findAll(queryCaptor.capture(), orderCaptor.capture());
+        verifyNoMoreInteractions(invoiceRepository);
+        verifyNoInteractions(visitRepository);
+        assertEquals("invoice.issued = " + at,
+                queryCaptor.getValue().toString());
+        assertEquals("invoice.issued ASC",
+                orderCaptor.getValue().toString());
+    }
+}

--- a/lib/backend-data/src/test/java/esy/app/clinic/InvoiceRepositoryTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/InvoiceRepositoryTest.java
@@ -1,0 +1,105 @@
+package esy.app.clinic;
+
+import esy.api.clinic.Invoice;
+import esy.api.clinic.InvoiceStatus;
+import esy.api.clinic.Visit;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Tag("slow")
+@SpringBootTest
+@Transactional
+@Rollback(true)
+public class InvoiceRepositoryTest {
+
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    @Autowired
+    private VisitRepository visitRepository;
+
+    Invoice createWithText(final String text) {
+        return Invoice.fromJson("""
+                {
+                    "issued":"2024-01-15",
+                    "period":"PT720H",
+                    "status":"D",
+                    "text":"%s"
+                }
+                """.formatted(text));
+    }
+
+    Visit saveVisit(final String date) {
+        return visitRepository.save(Visit.fromJson("""
+                {
+                    "date":"%s",
+                    "text":"Treatment"
+                }
+                """.formatted(date)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Tschüss und schöne Grüße!"
+    })
+    void saveInvoice(final String text) {
+        final var visit = saveVisit("2024-01-10");
+        final var value0 = createWithText(text).setVisit(visit);
+        assertFalse(value0.isPersisted());
+        assertEquals(0L, value0.getVersion());
+        assertNotNull(value0.getId());
+        assertEquals(text, value0.getText());
+        assertNotNull(value0.getIssued());
+        assertNotNull(value0.getPeriod());
+        assertEquals(InvoiceStatus.D, value0.getStatus());
+        assertNotNull(value0.getVisit());
+
+        final var value1 = invoiceRepository.save(value0);
+        assertNotNull(value1);
+        assertNotSame(value0, value1);
+        assertTrue(value1.isPersisted());
+        assertEquals(0L, value1.getVersion());
+        assertNotNull(value1.getVisit());
+        assertTrue(value1.isEqual(value0));
+    }
+
+    @Test
+    void findInvoice() {
+        final var text = "Lorem ipsum";
+        final var visit = saveVisit("2024-01-11");
+        final var value = invoiceRepository.save(createWithText(text).setVisit(visit));
+        assertTrue(invoiceRepository.existsById(value.getId()));
+        assertTrue(invoiceRepository.findById(value.getId()).orElseThrow().isEqual(value));
+    }
+
+    @Test
+    void findInvoiceNoElement() {
+        final var uuid = UUID.randomUUID();
+        assertFalse(invoiceRepository.existsById(uuid));
+        assertFalse(invoiceRepository.findById(uuid).isPresent());
+    }
+
+    @Test
+    void findAll() {
+        final var value1 = invoiceRepository.save(createWithText("Lorem ipsum").setVisit(saveVisit("2024-02-01")));
+        final var value2 = invoiceRepository.save(createWithText("Dolor sit amet").setVisit(saveVisit("2024-02-02")));
+        final var value3 = invoiceRepository.save(createWithText("Dolore magna aliqua").setVisit(saveVisit("2024-02-03")));
+        assertEquals(3, invoiceRepository.count());
+        final var allValue = invoiceRepository.findAll();
+        assertEquals(3, allValue.size());
+        assertTrue(allValue.remove(value1));
+        assertTrue(allValue.remove(value2));
+        assertTrue(allValue.remove(value3));
+        assertTrue(allValue.isEmpty());
+    }
+}

--- a/lib/backend-data/src/test/java/esy/app/clinic/InvoiceRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/InvoiceRestApiTest.java
@@ -1,0 +1,413 @@
+package esy.app.clinic;
+
+import esy.api.clinic.Invoice;
+import esy.app.DatabaseCleaner;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@Tag("slow")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@ExtendWith({MockitoExtension.class, RestDocumentationExtension.class})
+class InvoiceRestApiTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @Autowired
+    private InvoiceRepository invoiceRepository;
+
+    @BeforeEach
+    void setUp(final WebApplicationContext webApplicationContext,
+               final RestDocumentationContextProvider restDocumentation) {
+        mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
+                .apply(documentationConfiguration(restDocumentation))
+                .alwaysDo(document("{method-name}",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint())))
+                .build();
+    }
+
+    @Sql("/sql/visit.sql")
+    @Test
+    @Order(1)
+    void getApiInvoiceNoElement() throws Exception {
+        assertEquals(0, invoiceRepository.count());
+        mockMvc.perform(get("/api/invoice")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(jsonPath("$.content")
+                        .isArray())
+                .andExpect(jsonPath("$.content[0]")
+                        .doesNotExist());
+    }
+
+    @Test
+    @Order(200)
+    void postApiInvoice() throws Exception {
+        mockMvc.perform(post("/api/invoice")
+                        .content("""
+                                {
+                                    "visit":"/api/visit/f1111111-1111-beef-dead-beefdeadbeef",
+                                    "issued":"2024-01-15",
+                                    "period":"PT720H",
+                                    "status":"D",
+                                    "text":"Lorem ipsum."
+                                }
+                                """)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isCreated())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .string("ETag", "\"0\""))
+                .andExpect(jsonPath("$.id")
+                        .isNotEmpty())
+                .andExpect(jsonPath("$.issued")
+                        .value("2024-01-15"))
+                .andExpect(jsonPath("$.period")
+                        .value("PT720H"))
+                .andExpect(jsonPath("$.status")
+                        .value("D"))
+                .andExpect(jsonPath("$.text")
+                        .value("Lorem ipsum."));
+    }
+
+    @Test
+    @Order(201)
+    void postApiInvoiceConflict() throws Exception {
+        mockMvc.perform(post("/api/invoice")
+                        .content("""
+                                {
+                                    "visit":"/api/visit/f1111111-1111-beef-dead-beefdeadbeef",
+                                    "issued":"2024-01-15",
+                                    "period":"PT720H",
+                                    "status":"D",
+                                    "text":"Duplicate invoice."
+                                }
+                                """)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isConflict());
+    }
+
+    @Test
+    @Order(300)
+    void putApiInvoice() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertFalse(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(put("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "visit":"/api/visit/f2222222-2222-beef-dead-beefdeadbeef",
+                                    "issued":"2024-03-01",
+                                    "period":"PT720H",
+                                    "status":"I",
+                                    "text":"Dolor sit amet."
+                                }
+                                """)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isCreated())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .string("ETag", "\"0\""))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.issued")
+                        .value("2024-03-01"))
+                .andExpect(jsonPath("$.period")
+                        .value("PT720H"))
+                .andExpect(jsonPath("$.status")
+                        .value("I"))
+                .andExpect(jsonPath("$.text")
+                        .value("Dolor sit amet."));
+    }
+
+    @Test
+    @Order(400)
+    void patchApiInvoiceText() throws Exception {
+        final var text = "At vero eos";
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "text":"%s"
+                                }
+                                """.formatted(text))
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .string("ETag", "\"1\""))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.text")
+                        .value(text));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"C", "X"})
+    @Order(401)
+    void patchApiInvoiceStatus(final String status) throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "status":"%s"
+                                }
+                                """.formatted(status))
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .exists("ETag"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.status")
+                        .value(status));
+    }
+
+    @Test
+    @Order(402)
+    void patchApiInvoiceIssued() throws Exception {
+        final var issued = Invoice.DATE_FORMATTER.format(LocalDate.of(2024, 3, 15));
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "issued":"%s"
+                                }
+                                """.formatted(issued))
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .exists("ETag"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.issued")
+                        .value(issued));
+    }
+
+    @Test
+    @Order(403)
+    void patchApiInvoicePeriod() throws Exception {
+        final var period = Duration.ofDays(31).toString();
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "period":"%s"
+                                }
+                                """.formatted(period))
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .exists("ETag"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.period")
+                        .value(period));
+    }
+
+    @Test
+    @Order(404)
+    void patchApiInvoiceVisit() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/invoice/" + uuid)
+                        .content("""
+                                {
+                                    "visit":"/api/visit/f3333333-3333-beef-dead-beefdeadbeef"
+                                }
+                                """)
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .string("ETag", "\"6\""))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()));
+    }
+
+    @Test
+    @Order(405)
+    void getApiInvoiceVisit() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(get("/api/invoice/" + uuid + "/visit")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(jsonPath("$.id")
+                        .value("f3333333-3333-beef-dead-beefdeadbeef"));
+    }
+
+    @Test
+    @Order(500)
+    void getApiInvoice() throws Exception {
+        assertEquals(2, invoiceRepository.count());
+        mockMvc.perform(get("/api/invoice")
+                        .param("sort", "issued,asc")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(jsonPath("$.content")
+                        .isArray())
+                .andExpect(jsonPath("$.content[0]")
+                        .exists())
+                .andExpect(jsonPath("$.content[1]")
+                        .exists())
+                .andExpect(jsonPath("$.content[2]")
+                        .doesNotExist());
+    }
+
+    @Test
+    @Order(503)
+    void getApiInvoiceById() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(get("/api/invoice/" + uuid)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .exists("ETag"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()));
+    }
+
+    @Test
+    @Order(504)
+    void getApiInvoiceByIdNotFound() throws Exception {
+        final var uuid = UUID.fromString("e1111111-2222-beef-dead-beefdeadbeef");
+        assertFalse(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(get("/api/invoice/" + uuid)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isNotFound());
+    }
+
+    @Test
+    @Order(600)
+    void deleteApiInvoice() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(invoiceRepository.findById(uuid).isPresent());
+        mockMvc.perform(delete("/api/invoice/" + uuid)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()));
+    }
+
+    @Test
+    @Order(999)
+    @Transactional
+    @Rollback(false)
+    void cleanup() {
+        assertDoesNotThrow(() -> databaseCleaner.cleanDatabase());
+    }
+}

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
@@ -166,4 +166,31 @@ class VisitGraphqlTest {
         assertEquals("visit.date ASC",
                 orderCaptor.getValue().toString());
     }
+
+    @Test
+    void queryAllVisitByText() {
+        final var text = "Odi";
+        final var value = createWithText("Lorem ipsum.")
+                .setPet(createPet("Odi"));
+        when(visitRepository.findAll(any(BooleanExpression.class), any(OrderSpecifier.class)))
+                .thenReturn(List.of(value));
+        when(petRepository.findAllById(any()))
+                .thenReturn(List.of(value.getPet()));
+        final var data = graphQlTester
+                .document("""
+                        {allVisitByText(text: "%s"){date pet{name}}}
+                        """.formatted(text))
+                .execute();
+        assertNotNull(data);
+        data.path("allVisitByText[0].pet.name")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(value.getPet().getName());
+        final var queryCaptor = ArgumentCaptor.<BooleanExpression>captor();
+        final var orderCaptor = ArgumentCaptor.<OrderSpecifier<?>>captor();
+        verify(visitRepository).findAll(queryCaptor.capture(), orderCaptor.capture());
+        verifyNoMoreInteractions(visitRepository);
+        assertEquals("visit.date DESC",
+                orderCaptor.getValue().toString());
+    }
 }

--- a/lib/backend-data/src/test/resources/sql/visit.sql
+++ b/lib/backend-data/src/test/resources/sql/visit.sql
@@ -1,0 +1,6 @@
+INSERT INTO visit (id, date)
+    VALUES ('f1111111-1111-beef-dead-beefdeadbeef', '2024-01-10');
+INSERT INTO visit (id, date)
+    VALUES ('f2222222-2222-beef-dead-beefdeadbeef', '2024-01-20');
+INSERT INTO visit (id, date)
+    VALUES ('f3333333-3333-beef-dead-beefdeadbeef', '2024-01-30');


### PR DESCRIPTION
```
You are a backend developer. Create an enum InvoiceStatus with values D for drafted, I for issued, C for completed, and X for cancelled, in package clinic. Create an entity Invoice with required property issued of type LocalDate, with required property period of type Duration, with required property status of type InvoiceStatus, with required non-blank property text of type String, in package clinic. Every visit results in exactly one invoice for billing. Add a required one-to-
one relation from entity Invoice to entity Visit. Add tests for all layers, i.e. entity class, repository, controller for REST endpoints and controller for GraphQL operations. Create REST API documentation for invoice endpoints. Create
GraphQL API documentation for invoice operations.​
```
## Phase 1: lib/backend-api — Entity layer

**Step 1** (new): `lib/backend-api/src/main/java/esy/api/clinic/InvoiceStatus.java`
- Enum with values D("drafted"), I("issued"), C("completed"), X("cancelled")
- Uses `@RequiredArgsConstructor`, `@Getter`, `@Accessors(fluent = true)`, `private final String text`
- Tag: `// tag::enumerations[]` … `// end::enumerations[]`
- Pattern: identical to `Sex.java`

**Step 2** (new): `lib/backend-api/src/main/java/esy/api/clinic/VisitItem.java`
- Needed for Invoice.extraJson following the VetItem / PetItem / OwnerItem pattern
- Fields: `UUID value` (@Transient), `String text` (visit.getDate().toString())
- Static `fromValue(Visit)` factory, tag: `// tag::properties[]`
- Pattern: identical to `VetItem.java`

**Step 3** (new): `lib/backend-api/src/main/java/esy/api/clinic/Invoice.java`
- Entity, `@Table(name = "invoice")`, unique constraint on `id` and `visit_id`
- Constants: `DATE_PATTERN`, `DATE_FORMATTER`
- Properties (tag::properties):
  - `issued`: LocalDate, @NotNull, @JsonFormat DATE_PATTERN
  - `period`: Duration, @NotNull, @Convert(DurationConverter), @JsonFormat STRING
  - `status`: InvoiceStatus, @NotNull, @Enumerated(EnumType.STRING)
  - `text`: String, @NotBlank
  - `visit`: Visit, @NotNull, @OneToOne(fetch=LAZY, optional=false), @JoinColumn(visit_id), @JsonProperty(WRITE_ONLY)
- No-arg constructor with defaults: issued=2000-01-01, period=ZERO, status=D, text="", visit=null
- Methods: toString, isEqual, withId, extraJson (adds visitItem), writeJson, fromJson, setVisit(@JsonIgnore)
- Pattern: Visit.java + Pet.java combined

**Step 4** (new): `lib/backend-api/src/main/java/esy/api/clinic/Invoice.adoc`
- Fact sheet describing Invoice entity, its required fields, the one-to-one Visit relation

**Step 5** (new): `lib/backend-api/src/test/java/esy/api/clinic/InvoiceTest.java`
- @Tag("fast"), tests: equalsHashcodeToString, writeJson, withId, jsonIssued, jsonIssuedConstraints, jsonText, jsonTextConstraints
- createWithText factory method
- Pattern: OwnerTest.java / VisitTest.java

## Phase 2: lib/backend-data — Database

**Step 6** (new): `lib/backend-data/src/main/resources/liquibase/v1/invoice.xml`
- Creates table `invoice`: version BIGINT, id UUID PK, issued DATE NOT NULL, period BIGINT NOT NULL, status VARCHAR(1) NOT NULL, text VARCHAR(512) NOT NULL, visit_id UUID UNIQUE NOT NULL
- FK constraint fk_invoice_visit_id → visit(id)
- Pattern: visit.xml

**Step 7** (modify): `lib/backend-data/src/main/resources/liquibase/changelog.xml`
- Add `<include file="v1/invoice.xml" relativeToChangelogFile="true"/>` after visit.xml entry

**Step 8** (new): `lib/backend-data/src/test/resources/sql/visit.sql`
- 3 rows with e1111111…, e2222222…, e3333333… UUIDs
- References pet (c-prefix) and vet (d-prefix) from existing fixtures
- Needed by InvoiceRestApiTest @Sql annotations

## Phase 3: lib/backend-data — Backend implementation

**Step 9** (new): `lib/backend-data/src/main/java/esy/app/clinic/InvoiceRepository.java`
- `@RepositoryRestResource(path="invoice", collectionResourceRel="allInvoice")`
- Extends `JsonJpaRepository<Invoice>` and `QuerydslRepository<Invoice, QInvoice>`
- customize: bind String (stringContainsOrLikeIgnoreCaseBinding), bind root.issued (localDateEqBetweenInBinding)
- Pattern: VisitRepository.java

**Step 10** (new): `lib/backend-data/src/main/java/esy/app/clinic/InvoiceRestController.java`
- `@RepositoryEventHandler`, `@BasePathAwareController`
- Extends `JsonJpaRestControllerBase<Invoice>`
- Pattern: VisitRestController.java

**Step 11** (new): `lib/backend-data/src/main/resources/graphql/InvoiceStatus.gqls`
- `enum InvoiceStatus { D I C X }`
- Pattern: Sex.gqls

**Step 12** (new): `lib/backend-data/src/main/resources/graphql/Invoice.gqls`
- `type Invoice { id: ID!, issued: LocalDate!, period: String!, status: InvoiceStatus!, text: String!, visit: Visit }`
- Pattern: Visit.gqls

**Step 13** (modify): `lib/backend-data/src/main/resources/graphql/Query.gqls`
- Add: `allInvoice: [Invoice]`, `allInvoiceByStatus(status: InvoiceStatus!): [Invoice]`, `invoiceByVisitId(id: ID!): Invoice`

**Step 14** (new): `lib/backend-data/src/main/java/esy/app/clinic/InvoiceGraphqlController.java`
- @Controller, @RequiredArgsConstructor
- Fields: InvoiceRepository, VisitRepository
- @QueryMapping allInvoice(), allInvoiceByStatus(@Argument status), invoiceByVisitId(@Argument("id") UUID)
- @BatchMapping visit(List<Invoice>) → Mono<Map<Invoice, Visit>>
- Pattern: VisitGraphqlController.java

## Phase 4: lib/backend-data — Tests

**Step 15** (new): `lib/backend-data/src/test/java/esy/app/clinic/InvoiceRepositoryTest.java`
- @Tag("slow"), @SpringBootTest, @Transactional, @Rollback
- Helper: saveVisit() that creates and saves a Visit (using existing VisitRepository, pet/vet helpers)
- Tests: saveInvoice (with visit), findInvoice, findInvoiceNoElement, findAll (with QueryDSL by status and visit)
- Pattern: VisitRepositoryTest.java

**Step 16** (new): `lib/backend-data/src/test/java/esy/app/clinic/InvoiceRestApiTest.java`
- @Tag("slow"), @SpringBootTest, @AutoConfigureMockMvc, @TestMethodOrder, @ExtendWith(RestDocumentation)
- @Sql("/sql/owner.sql"), @Sql("/sql/pet.sql"), @Sql("/sql/vet.sql"), @Sql("/sql/visit.sql")
- Tests: getApiInvoiceNoElement, postApiInvoice (parametrized by status), postApiInvoiceConflict (duplicate visit), putApiInvoice, patchApiInvoice-*, getApiInvoice, getApiInvoiceById, getApiInvoiceVisit, deleteApiInvoice
- Pattern: VisitRestApiTest.java

**Step 17** (new): `lib/backend-data/src/test/java/esy/app/clinic/InvoiceGraphqlTest.java`
- @Tag("fast"), @GraphQlTest(InvoiceGraphqlController.class), @Import(EsyGraphqlConfiguration.class)
- MockitoBeans: InvoiceRepository, VisitRepository
- Tests: queryAllInvoice, queryAllInvoiceByStatus, queryAllInvoiceWithVisit, queryInvoiceByVisitId
- Pattern: VisitGraphqlTest.java

## Phase 5: Documentation

**Step 18** (new): `doc/service/invoice-restapi.adoc`
- Model: Invoice (aggregate root with entity fact sheet, Liquibase script, entity source tag), InvoiceStatus (enum source tag), Visit (referenced entity)
- Operations: POST, PUT, PATCH (issued, period, status, text, visit), GET collection (with query param examples), GET by id, GET /{id}/visit, DELETE
- Pattern: visit-restapi.adoc

**Step 19** (new): `doc/service/invoice-graphql.adoc`
- Model: Invoice (schema), InvoiceStatus (schema), BatchMapping note for visit relation
- Queries: allInvoice, allInvoiceByStatus, invoiceByVisitId
- Pattern: visit-graphql.adoc

## Relevant files

- `lib/backend-api/src/main/java/esy/api/clinic/Visit.java` — one-to-one source, date pattern, Duration usage
- `lib/backend-api/src/main/java/esy/api/clinic/VetItem.java` — VisitItem template
- `lib/backend-api/src/main/java/esy/api/basis/Sex.java` — InvoiceStatus enum template
- `lib/backend-api/src/main/java/esy/api/client/Pet.java` — @Enumerated(STRING) and @OneToOne pattern
- `lib/backend-data/src/main/java/esy/app/clinic/VisitRepository.java` — repository template
- `lib/backend-data/src/main/java/esy/app/clinic/VisitRestController.java` — REST controller template
- `lib/backend-data/src/main/java/esy/app/clinic/VisitGraphqlController.java` — GraphQL controller template
- `lib/backend-data/src/main/resources/liquibase/changelog.xml` — **modify**: add invoice.xml include
- `lib/backend-data/src/main/resources/graphql/Query.gqls` — **modify**: add 3 invoice queries
- `lib/backend-data/src/main/resources/liquibase/v1/visit.xml` — invoice.xml template

## Verification

1. Run `./gradlew :lib:backend-api:test` — InvoiceTest must pass
2. Run `./gradlew :lib:backend-data:test` — InvoiceRepositoryTest, InvoiceRestApiTest, InvoiceGraphqlTest must pass
3. Check that `GET /api/invoice` returns 200 with empty collection
4. Check that `POST /api/invoice` with duplicate visit_id returns 409 Conflict
5. Verify `invoiceByVisitId` GraphQL query returns correct Invoice
6. Verify `allInvoiceByStatus` GraphQL query filters correctly
7. Run `./gradlew spotlessApply` to format all Java files

## Decisions

- `status` stored as VARCHAR(1) with `@Enumerated(EnumType.STRING)` — readable in DB, consistent with `Sex`
- `period` stored as BIGINT seconds via `DurationConverter` — consistent with Visit.duration
- `visit_id` is UNIQUE in invoice table — enforces the one-to-one constraint at DB level
- `VisitItem` added to follow the established extraJson Item pattern
- `InvoiceStatus.gqls` is a separate file — follows "file name matches entity class name" from AGENTS.md
- `invoiceByVisitId` returns nullable `Invoice` (not a list) — appropriate for one-to-one lookup
- Default status in no-arg constructor: `InvoiceStatus.D` (drafted)
- visit.sql test fixture created with prefix `e` UUIDs — follows the existing b/c/d/e naming pattern

```
You are a frontend developer. Create lister, editor and viewer components for entity Invoice in package clinic for the angular and svelte client. For period in the invoice editor add input fields for days only (ignore others) derived from the ISO-8601 string (e.g. "PT7D") with title "Paymend period in days". Add a menu button for the invoice lister. Add a visit picker to the invoice editor. The picker loads dynamically visits, filtered by a text that applies to the pet name and the owner name. The visits are displayed with a composite text constructed with the followin format: "{pet.name} of {owner.name},{owner.address} at {visit.date}. If more than one element exists then the user can select exactly one. Use the GraphQL API to tailor the data needed for the picker. Add a query to the GraphQL API if needed. Use RxJs for data loading.
```
