### PR TITLE
copilot: Agent aktualisiert Lister inkl. Editor und CRUD-Service für ein Domänenobjekt

### DIFF
--- a/.github/agents/angular-editor-update.agent.md
+++ b/.github/agents/angular-editor-update.agent.md
@@ -1,0 +1,58 @@
+---
+name: Angular editor component updater
+description: |
+  Updates the editor component for all properties of an entity.
+  Updates the service component for entity data retrieval.
+---
+
+## Task preconditions
+
+You MUST NOT generate code if even one of the preconditions is not met.
+
+1. **Identify target entity**
+  Extract the entity name from the request.
+  Check if name is a valid identifier for the programming languages Java, Typescript and SQL.
+  Check that NO entity class with this name already exists.
+  Replace placeholder `<Entity>` with the given name.
+  Replace placeholder `<entity>` with lowercase name.
+
+2. **Identify target domain package**
+  Extract the domain package name from the request.
+  Check if name is a valid identifier for the programming languages Java, Typescript and SQL.
+  Check that a package directory with this name exists.
+  Replace placeholder `<package>` with the given name
+
+3. **Locate implementation files**
+  Locate existing implementation files:
+  - **Entity classes** → Check *.java in lib/backend-api/src/main/java/**/api/**
+  - **Angular types** → Check *.type.ts in app/client-angular/src/main/angular/types
+  - **Angular services** → Check *.service.ts in app/client-angular/src/main/angular/types
+  - **Angular routes** → Check *.routes.ts in app/client-angular/src/main/angular/pages/**
+  - **Angular editor components** → Check *.[ts|html|css] in app/client-angular/src/main/angular/pages/**/*-editor
+  - **Angular lister components** → Check *.[ts|html|css] in app/client-angular/src/main/angular/pages/**/*-lister
+  
+4. **Locate documentation files**
+  Locate existing implementation files that affect documentation:
+  - **REST API service documentation** → Check *restapi.adoc in doc/service/**
+  - **GraphQL service documentation** → Check *graphql.adoc in doc/service/**
+  
+## Task steps
+
+1. **Update entity type**
+  Synchronize entity type script `<entity>.type.ts` with entity class `<Entity>.java`.
+
+3. **Update entity editor component**
+  Use `doc/concept/angular/entity-editor.adoc` as the implementation baseline.
+  Create directory `src/main/angular/pages/<package>/<entity>-editor`.
+  Create component script `<entity>-editor.ts`.
+  Create component layout `<entity>-editor.html`.
+  Add controls to edit new properties of the entity.
+  Do not show or edit the primary key or the version of the entity.
+
+4. **Update entity lister component**
+  Use `doc/concept/angular/entity-lister.adoc` as the implementation baseline.
+  If needed, load extra data and pass it to the editor component.
+
+## Task output
+
+Create a short summary with files changed.

--- a/.github/agents/angular-lister-create.agent.md
+++ b/.github/agents/angular-lister-create.agent.md
@@ -1,0 +1,68 @@
+---
+name: Angular lister component creator
+description: |
+  Creates a lister component for an entity.
+  Creates an editor component for all properties of an entity.
+  Creates a service component for entity data retrieval.
+---
+
+## Task preconditions
+
+You MUST NOT generate code if even one of the preconditions is not met.
+
+1. **Identify target entity**
+  Extract the entity name from the request.
+  Check if name is a valid identifier for the programming languages Java, Typescript and SQL.
+  Check that NO entity class with this name already exists.
+  Replace placeholder `<Entity>` with the given name.
+  Replace placeholder `<entity>` with lowercase name.
+
+2. **Identify target domain package**
+  Extract the domain package name from the request.
+  Check if name is a valid identifier for the programming languages Java, Typescript and SQL.
+  Check that a package directory with this name exists.
+  Replace placeholder `<package>` with the given name.
+
+3. **Locate implementation files**
+  Locate existing implementation files:
+  - **Entity classes** → Check *.java in lib/backend-api/src/main/java/**/api/**
+  - **Angular types** → Check *.type.ts in app/client-angular/src/main/angular/types
+  - **Angular services** → Check *.service.ts in app/client-angular/src/main/angular/types
+  - **Angular routes** → Check *.routes.ts in app/client-angular/src/main/angular/pages/**
+  - **Angular editor components** → Check *.[ts|html|css] in app/client-angular/src/main/angular/pages/**/*-editor
+  - **Angular lister components** → Check *.[ts|html|css] in app/client-angular/src/main/angular/pages/**/*-lister
+  
+4. **Locate documentation files**
+  Locate existing implementation files that affect documentation:
+  - **REST API service documentation** → Check *restapi.adoc in doc/service/**
+  - **GraphQL service documentation** → Check *graphql.adoc in doc/service/**
+
+## Task steps
+
+1. **Create entity type**
+  Create entity type script `<entity>.type.ts` for entity class `<Entity>.java`.
+
+2. **Create entity service**
+  Use `doc/concept/angular/entity-service.adoc` as the implementation baseline.
+  Use `doc/service/<entity>-restapi.adoc` as the REST API specification.
+  Create entity service script `<entity>.service.ts` for REST API access.
+
+3. **Create entity editor component**
+  Use `doc/concept/angular/entity-editor.adoc` as the implementation baseline.
+  Create directory `src/main/angular/pages/<package>/<entity>-editor`.
+  Create component script `<entity>-editor.ts`.
+  Create component layout `<entity>-editor.html`.
+  Add controls to edit all properties of the entity.
+  Do not show or edit the primary key or the version of the entity.
+
+4. **Create entity lister component**
+  Use `doc/concept/angular/entity-lister.adoc` as the implementation baseline.
+  Create directory `src/main/angular/pages/<package>/<entity>-lister`.
+  Create component script `<entity>-lister.ts`.
+  Create component layout `<entity>-lister.html`.
+  Find the minimum set of properties needed to identify the entity, e.g. name.
+  Use those properties for column names in the table.
+
+## Task output
+
+Create a short summary with files changed.

--- a/PROMPT.adoc
+++ b/PROMPT.adoc
@@ -138,3 +138,12 @@ The agent reviews implementation files for all REST API endpoints and updates th
 
 The agent reviews implementation files for all GraphQL API operations for the given main entity and creates a new documentation following structure and instructions of the template.
 Replace `owner` with the name of the main entity.
+
+== Angular lister component creator
+
+.Prompt
+----
+@copilot Create a lister component for entity Invoice in package clinic
+----
+
+The agent reviews implementation files for the given entity and creates a lister component for the angular based client.

--- a/PROMPT.adoc
+++ b/PROMPT.adoc
@@ -15,135 +15,102 @@ for a community created collection of custom agents and instructions.
 
 .Prompt
 ----
-@copilot check domain entities
+@copilot Check domain entities
 ----
-
-The agent reviews implementation files for all domain entities, fixes minor issues or leaves hints and instructions to fix issues.
-
-You can reduce the scope to changed files in a pull request.
 
 .Prompt
 ----
-@copilot in the collections skill and species of entity Vet is now a new element constraint. Add tests to #file:VetTest.java if needed.
+@copilot In the collections skill and species of entity Vet is now a new element constraint. Add tests to #file:VetTest.java if needed.
 ----
-
-The agent reviews implementation files for domain entity `Vet` after a change in the constraints of the collections `skill` and `species`.
-According to the rules in the implementation guides the agent adds tests to verify the new validation logic.
 
 == Domain entity creator
 
 .Prompt
 ----
-@copilot create an entity VisitInvoice with a required many-to-one relation to entity Visit, with required property at of type LocalDate, with required property due of type LocalDate, with required non-blank property text of type String.
+@copilot Create an entity VisitInvoice with a required many-to-one relation to entity Visit, with required property at of type LocalDate, with required property due of type LocalDate, with required non-blank property text of type String.
 ----
-
-The agent implements a new entity with name `VisitInvoice` and properties `at`, `due` and `text` and creates all specified tests.
 
 == Domain entity property adder
 
 .Prompt
 ----
-@copilot add property text of type String to entity Visit having a diagnosis text.
+@copilot Add property text of type String to entity Visit having a diagnosis text.
 ----
-
-The agent implements a new property with name `text` of type `String` to entity class `Visit` and applies changes to tests.
 
 .Prompt
 ----
-@copilot remove property billable of type boolean from entity Visit.
+@copilot Remove property billable of type boolean from entity Visit.
 ----
-
-The agent removes the existing property with name `billable` of type `boolean` from entity class `Visit` and applies changes to tests.
-It does the inverse of the tasks of the implementation guide.
 
 == Domain entity collection adder
 
 .Prompt
 ----
-@copilot add collection skill of type String to entity Vet having skills of vets.
+@copilot Add collection skill of type String to entity Vet having skills of vets.
 ----
-
-The agent implements a new collection with name `skill` of type `String` to entity class `Vet` and applies changes to tests.
 
 == Domain entity many-to-one relation adder
 
 .Prompt
 ----
-@copilot add many-to-one relation pet of type Pet from entity Vet to entity Pet representing the pet treated in a visit.
+@copilot Add many-to-one relation pet of type Pet from entity Vet to entity Pet representing the pet treated in a visit.
 ----
-
-The agent implements a new many-to-one relation with name `pet` of type `Pet` to entity class `Visit` and applies changes to tests.
 
 == Domain entity one-to-many relation adder
 
 .Prompt
 ----
-@copilot add one-to-many relation pet of type Pet from entity Owner to entity Pet representing a list of pets owned by an owner.
+@copilot Add one-to-many relation pet of type Pet from entity Owner to entity Pet representing a list of pets owned by an owner.
 ----
-
-The agent implements a new one-to-many relation with name `pet` of type `Pet` to entity class `Owner` and applies changes to tests.
 
 == REST API sanity checker
 
 .Prompt
 ----
-@copilot check rest api
+@copilot Check REST API documentation
 ----
-
-The agent reviews implementation files for all REST API endpoints and ensures related REST API documentation is up-to-date, fixes minor issues or leaves hints and instructions to fix issues.
-
-You can reduce the scope to changed files in a pull request.
 
 == REST API service documentation creator
 
 .Prompt
 ----
-@copilot update rest api documentation
+@copilot Update REST API documentation
 ----
-
-The agent reviews implementation files for all REST API endpoints and updates the documentation following structure and instructions of the template.
 
 .Prompt
 ----
-@copilot create rest api documentation for owner endpoints
+@copilot Create REST API documentation for owner endpoints
 ----
-
-The agent reviews implementation files for all REST API endpoints for the given main entity and creates a new documentation following structure and instructions of the template.
-Replace `owner` with the name of the main entity.
 
 == GraphQL API sanity checker
 
 .Prompt
 ----
-@copilot check graphql api
+@copilot Check GraphQL API
 ----
-
-The agent reviews implementation files for all GraphQL API operations and ensures related GraphQL API documentation is up-to-date, fixes minor issues or leaves hints and instructions to fix issues.
-
-You can reduce the scope to changed files in a pull request.
 
 == GraphQL API service documentation creator
 
 .Prompt
 ----
-@copilot update graphql documentation
+@copilot Update GraphQL API documentation
 ----
-
-The agent reviews implementation files for all REST API endpoints and updates the documentation following structure and instructions of the template.
 
 .Prompt
 ----
-@copilot create graphql api documentation for owner operations
+@copilot Create GraphQL API documentation for owner operations
 ----
-
-The agent reviews implementation files for all GraphQL API operations for the given main entity and creates a new documentation following structure and instructions of the template.
-Replace `owner` with the name of the main entity.
 
 == Angular lister component creator
 
 .Prompt
 ----
-@copilot Create a lister component for entity Invoice in package clinic
+@copilot Create editor and lister components for entity Invoice in package clinic
 ----
 
-The agent reviews implementation files for the given entity and creates a lister component for the angular based client.
+== Angular editor component updater
+
+.Prompt
+----
+@copilot Update editor and lister components for the new collection allSpecies of the Vet entity. Use allSkill as a good example.
+----

--- a/PROMPT.adoc
+++ b/PROMPT.adoc
@@ -108,6 +108,11 @@ for a community created collection of custom agents and instructions.
 @copilot Create editor and lister components for entity Invoice in package clinic
 ----
 
+.Prompt
+----
+@copilot Verify existing lister and editor components if they are compliant to the implentation guide
+----
+
 == Angular editor component updater
 
 .Prompt

--- a/app/client-angular/playwright.config.js
+++ b/app/client-angular/playwright.config.js
@@ -7,8 +7,8 @@ const config = {
   testMatch: /.+\.e2e\.js/,
   /* See https://playwright.dev/docs/api/class-testconfig#test-config-test-ignore */
   testIgnore: "**/*Page.js",
-  /* Maximum time one test can run for. */
-  timeout: process.env.PWDEBUG ? 0 : 5000,
+  /* See https://playwright.dev/docs/api/class-testconfig#test-config-timeout */
+  timeout: process.env.PWDEBUG ? 0 : 10000,
   /* See https://playwright.dev/docs/api/class-testconfig#test-config-expect */
   expect: {
     /* Maximum time expect() should wait for the condition to be met. */

--- a/app/client-angular/src/main/angular/pages/client/owner-lister/owner-lister.ts
+++ b/app/client-angular/src/main/angular/pages/client/owner-lister/owner-lister.ts
@@ -108,9 +108,13 @@ export class OwnerListerComponent implements OnInit {
 
   allSpeciesEnum = signal<EnumItem[]>([]);
   ngOnInit() {
+    this.loading.set(true);
     const subscription = this.enumService.loadAllEnum("species").subscribe({
       next: (allSpeciesEnum) => {
         this.allSpeciesEnum.set(allSpeciesEnum);
+      },
+      complete: () => {
+        this.loading.set(false);
       },
       error: (err) => {
         this.toast.push(err);

--- a/app/client-angular/src/main/angular/pages/client/owner-lister/owner-lister.ts
+++ b/app/client-angular/src/main/angular/pages/client/owner-lister/owner-lister.ts
@@ -131,6 +131,8 @@ export class OwnerListerComponent implements OnInit {
 
   onFilterClicked() {
     this.loading.set(true);
+    // Do not trigger with each change of the criteria.
+    // Reload only when clicking the search button.
     const search = {
       sort: "name,asc",
       name: this.filterForm.value.criteria || "%",

--- a/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts
@@ -194,7 +194,7 @@ export class PetListerComponent implements OnInit {
     this.petId.set(undefined); // no pet selected
     const text = [pet.species, pet.name].join(" ");
     const hint = text.length > 20 ? text.substring(0, 20) + "..." : text;
-    if (!confirm("Delete enum '" + hint + "' permanently?")) return;
+    if (!confirm("Delete pet '" + hint + "' permanently?")) return;
     this.loading.set(true);
     const subscription = this.petService.removePet(pet.id!).subscribe({
       next: (pet) => {

--- a/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts
@@ -100,6 +100,7 @@ export class PetListerComponent implements OnInit {
     };
   });
 
+  // tag::ngOnInit[]
   allSpeciesEnum = signal<EnumItem[]>([]);
   allOwnerItem = signal<OwnerItem[]>([]);
   ngOnInit() {
@@ -123,14 +124,15 @@ export class PetListerComponent implements OnInit {
       subscription.unsubscribe();
     });
   }
+  // end::ngOnInit[]
 
   constructor() {
     effect(() => this.onFilterClicked());
   }
 
+  // tag::onFilterClicked[]
   onFilterClicked() {
     this.loading.set(true);
-    // tag::loadAll[]
     const search = { sort: "name,asc", "owner.id": this.ownerId() };
     const subscription = this.petService.loadAllPet(search).subscribe({
       next: (allPet) => {
@@ -145,11 +147,11 @@ export class PetListerComponent implements OnInit {
         this.toast.push(err);
       },
     });
-    // end::loadAll[]
     this.destroyRef.onDestroy(() => {
       subscription.unsubscribe();
     });
   }
+  // end::onFilterClicked[]
 
   petId = signal<string | undefined>(undefined); // no pet selected
   onPetClicked(pet: Pet) {

--- a/app/client-angular/src/main/angular/pages/clinic/vet-editor/vet-editor.html
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-editor/vet-editor.html
@@ -25,6 +25,21 @@
         }
       </select>
     </fieldset>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Species</legend>
+      <select
+        formControlName="allSpecies"
+        aria-label="Species"
+        multiple
+        [size]="allSpeciesEnum().length"
+        class="select w-full"
+        placeholder="Choose species"
+      >
+        @for (speciesEnum of allSpeciesEnum(); track speciesEnum.code) {
+          <option [value]="speciesEnum.name">{{ speciesEnum.name }}</option>
+        }
+      </select>
+    </fieldset>
   </div>
   <div class="join py-4">
     <button type="submit" class="btn join-item" [disabled]="!isSubmittable">

--- a/app/client-angular/src/main/angular/pages/clinic/vet-editor/vet-editor.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-editor/vet-editor.ts
@@ -30,10 +30,12 @@ export class VetEditorComponent implements OnInit {
   private vetService = inject(VetService);
   visible = model.required<boolean>();
   allSkillEnum = input.required<EnumItem[]>();
+  allSpeciesEnum = input.required<EnumItem[]>();
   vet = input.required<Vet>();
   form = new FormGroup({
     name: new FormControl("", Validators.required),
     allSkill: new FormControl<string[]>([], Validators.required),
+    allSpecies: new FormControl<string[]>([], Validators.required),
   });
 
   ngOnInit() {
@@ -58,6 +60,7 @@ export class VetEditorComponent implements OnInit {
       ...this.vet(),
       name: this.form.value.name!,
       allSkill: this.form.value.allSkill!,
+      allSpecies: this.form.value.allSpecies!,
     };
     if (this.vet().id) {
       const subscription = this.vetService

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.html
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.html
@@ -55,6 +55,7 @@
                 (create)="afterCreateVet($event)"
                 [(visible)]="vetEditorCreate"
                 [allSkillEnum]="allSkillEnum()"
+                [allSpeciesEnum]="allSpeciesEnum()"
                 [vet]="newVet()"
               />
             </td>
@@ -109,6 +110,7 @@
                   (update)="afterUpdateVet($event)"
                   [(visible)]="vetEditorUpdate"
                   [allSkillEnum]="allSkillEnum()"
+                  [allSpeciesEnum]="allSpeciesEnum()"
                   [vet]="vet"
                 />
               </td>

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.html
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.html
@@ -50,7 +50,7 @@
       <tbody>
         @if (vetEditorCreate()) {
           <tr>
-            <td class="px-2" colspan="3">
+            <td class="border-l-4 px-2" colspan="3">
               <app-vet-editor
                 (create)="afterCreateVet($event)"
                 [(visible)]="vetEditorCreate"

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
@@ -15,6 +15,7 @@ import {
   Validators,
 } from "@angular/forms";
 import { RouterLink } from "@angular/router";
+import { forkJoin } from "rxjs";
 import { Toast } from "../../../controls/toast/toast";
 import { EnumService } from "../../../services/enum.service";
 import { VetService } from "../../../services/vet.service";
@@ -68,9 +69,13 @@ export class VetListerComponent implements OnInit {
   allSkillEnum = signal<EnumItem[]>([]);
   allSpeciesEnum = signal<EnumItem[]>([]);
   ngOnInit() {
-    const subscription = this.enumService.loadAllEnum("skill").subscribe({
-      next: (allSkillEnum) => {
+    const subscription = forkJoin({
+      allSkillEnum: this.enumService.loadAllEnum("skill"),
+      allSpeciesEnum: this.enumService.loadAllEnum("species"),
+    }).subscribe({
+      next: ({ allSkillEnum, allSpeciesEnum }) => {
         this.allSkillEnum.set(allSkillEnum);
+        this.allSpeciesEnum.set(allSpeciesEnum);
       },
       error: (err) => {
         this.toast.push(err);
@@ -78,19 +83,6 @@ export class VetListerComponent implements OnInit {
     });
     this.destroyRef.onDestroy(() => {
       subscription.unsubscribe();
-    });
-    const subscriptionSpecies = this.enumService
-      .loadAllEnum("species")
-      .subscribe({
-        next: (allSpeciesEnum) => {
-          this.allSpeciesEnum.set(allSpeciesEnum);
-        },
-        error: (err) => {
-          this.toast.push(err);
-        },
-      });
-    this.destroyRef.onDestroy(() => {
-      subscriptionSpecies.unsubscribe();
     });
   }
 

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
@@ -69,6 +69,7 @@ export class VetListerComponent implements OnInit {
   allSkillEnum = signal<EnumItem[]>([]);
   allSpeciesEnum = signal<EnumItem[]>([]);
   ngOnInit() {
+    this.loading.set(true);
     const subscription = forkJoin({
       allSkillEnum: this.enumService.loadAllEnum("skill"),
       allSpeciesEnum: this.enumService.loadAllEnum("species"),
@@ -76,6 +77,9 @@ export class VetListerComponent implements OnInit {
       next: ({ allSkillEnum, allSpeciesEnum }) => {
         this.allSkillEnum.set(allSkillEnum);
         this.allSpeciesEnum.set(allSpeciesEnum);
+      },
+      complete: () => {
+        this.loading.set(false);
       },
       error: (err) => {
         this.toast.push(err);

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
@@ -96,6 +96,8 @@ export class VetListerComponent implements OnInit {
 
   onFilterClicked() {
     this.loading.set(true);
+    // Do not trigger with each change of the criteria.
+    // Reload only when clicking the search button.
     const search = {
       sort: "name,asc",
       name: this.filterForm.value.criteria || "%",

--- a/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.ts
@@ -61,10 +61,12 @@ export class VetListerComponent implements OnInit {
       version: 0,
       name: "",
       allSkill: [],
+      allSpecies: [],
     };
   });
 
   allSkillEnum = signal<EnumItem[]>([]);
+  allSpeciesEnum = signal<EnumItem[]>([]);
   ngOnInit() {
     const subscription = this.enumService.loadAllEnum("skill").subscribe({
       next: (allSkillEnum) => {
@@ -76,6 +78,19 @@ export class VetListerComponent implements OnInit {
     });
     this.destroyRef.onDestroy(() => {
       subscription.unsubscribe();
+    });
+    const subscriptionSpecies = this.enumService
+      .loadAllEnum("species")
+      .subscribe({
+        next: (allSpeciesEnum) => {
+          this.allSpeciesEnum.set(allSpeciesEnum);
+        },
+        error: (err) => {
+          this.toast.push(err);
+        },
+      });
+    this.destroyRef.onDestroy(() => {
+      subscriptionSpecies.unsubscribe();
     });
   }
 

--- a/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
@@ -15,7 +15,6 @@ import {
   Validators,
 } from "@angular/forms";
 import { RouterLink } from "@angular/router";
-import { forkJoin } from "rxjs";
 import { Toast } from "../../../controls/toast/toast";
 import { VetService } from "../../../services/vet.service";
 import { VisitService } from "../../../services/visit.service";
@@ -88,18 +87,9 @@ export class VisitListerComponent implements OnInit {
 
   allVetItem = signal<VetItem[]>([]);
   ngOnInit() {
-    this.loading.set(true);
-    const search = { sort: "date,asc" };
-    const subscription = forkJoin({
-      allVetItem: this.vetService.loadAllVetItem(),
-      allVisit: this.visitService.loadAllVisit(search),
-    }).subscribe({
-      next: (value) => {
-        this.allVetItem.set(value.allVetItem);
-        this.allVisit.set(value.allVisit);
-      },
-      complete: () => {
-        this.loading.set(false);
+    const subscription = this.vetService.loadAllVetItem().subscribe({
+      next: (allVetItem) => {
+        this.allVetItem.set(allVetItem);
       },
       error: (err) => {
         this.toast.push(err);

--- a/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
@@ -44,12 +44,10 @@ export class VisitListerComponent implements OnInit {
     criteria: new FormControl("", Validators.required),
   });
 
+  // Visits are created via the pet treatment workflow,
+  // not inline in this lister.
+
   allVisit = signal<Visit[]>([]);
-  afterCreateVisit(newVisit: Visit) {
-    this.allVisit.update((allVisit) => {
-      return [newVisit, ...allVisit];
-    });
-  }
   afterUpdateVisit(newVisit: Visit) {
     this.allVisit.update((allVisit) => {
       return allVisit.map((visit) =>
@@ -76,14 +74,6 @@ export class VisitListerComponent implements OnInit {
       return true;
     }
   }
-
-  newVisit = computed<Visit>(() => {
-    return {
-      version: 0,
-      date: "",
-      text: "",
-    };
-  });
 
   allVetItem = signal<VetItem[]>([]);
   ngOnInit() {
@@ -128,23 +118,13 @@ export class VisitListerComponent implements OnInit {
     this.visitId.set(visit.id);
   }
 
-  visitEditorCreate = signal(false);
-  onVisitEditorCreateClicked() {
-    this.visitId.set(undefined); // no visit selected
-    this.visitEditorCreate.set(true);
-    this.visitEditorUpdate.set(false);
-  }
-
   visitEditorUpdate = signal(false);
   onVisitEditorUpdateClicked(visit: Visit) {
     this.visitId.set(visit.id);
-    this.visitEditorCreate.set(false);
     this.visitEditorUpdate.set(true);
   }
 
-  readonly visitFilterDisabled = computed(
-    () => this.visitEditorCreate() || this.visitEditorUpdate()
-  );
+  readonly visitFilterDisabled = computed(() => this.visitEditorUpdate());
 
   readonly visitEditorDisabled = computed(() => this.visitFilterDisabled());
 

--- a/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
@@ -40,10 +40,6 @@ export class VisitListerComponent implements OnInit {
   private visitService = inject(VisitService);
   loading = signal(false);
 
-  filterForm = new FormGroup({
-    criteria: new FormControl("", Validators.required),
-  });
-
   // Visits are created via the pet treatment workflow,
   // not inline in this lister.
 

--- a/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts
@@ -77,9 +77,13 @@ export class VisitListerComponent implements OnInit {
 
   allVetItem = signal<VetItem[]>([]);
   ngOnInit() {
+    this.loading.set(true);
     const subscription = this.vetService.loadAllVetItem().subscribe({
       next: (allVetItem) => {
         this.allVetItem.set(allVetItem);
+      },
+      complete: () => {
+        this.loading.set(false);
       },
       error: (err) => {
         this.toast.push(err);

--- a/app/client-angular/src/main/angular/types/vet.type.ts
+++ b/app/client-angular/src/main/angular/types/vet.type.ts
@@ -3,6 +3,7 @@ export interface Vet {
   version: number;
   name: string;
   allSkill: string[];
+  allSpecies: string[];
 }
 
 export interface VetItem {

--- a/app/client-angular/src/test/playwright/App.e2e.js
+++ b/app/client-angular/src/test/playwright/App.e2e.js
@@ -68,7 +68,7 @@ test.describe("Pet", () => {
 });
 
 test.describe("Vet", () => {
-  test("VetLister", { timeout: 3_000 }, async ({ page }) => {
+  test("VetLister", { timeout: 5_000 }, async ({ page }) => {
     const vetPage = new VetListerPage(page);
     await vetPage.goto();
     const vetName = await vetPage.createVet();

--- a/app/client-angular/src/test/playwright/pages/VetListerPage.js
+++ b/app/client-angular/src/test/playwright/pages/VetListerPage.js
@@ -37,6 +37,12 @@ export class VetListerPage {
     await skillsSelect.selectOption(["Radiology"]);
     await skillsSelect.press("Tab");
     await expect(skillsSelect).toHaveValues([/Radiology/]);
+    // Species
+    const speciesSelect = this.page.locator('[aria-label="Species"]');
+    await expect(speciesSelect).toHaveValues([]);
+    await speciesSelect.selectOption(["Cat"]);
+    await speciesSelect.press("Tab");
+    await expect(speciesSelect).toHaveValues([/Cat/]);
     // Ok
     const okButton = this.page.getByRole("button", { name: "Ok", exact: true });
     await expect(okButton).toBeEnabled();

--- a/app/client-svelte/playwright.config.js
+++ b/app/client-svelte/playwright.config.js
@@ -7,8 +7,8 @@ const config = {
   testMatch: /.+\.e2e\.js/,
   /* See https://playwright.dev/docs/api/class-testconfig#test-config-test-ignore */
   testIgnore: "**/*Page.js",
-  /* Maximum time one test can run for. */
-  timeout: process.env.PWDEBUG ? 0 : 5000,
+  /* See https://playwright.dev/docs/api/class-testconfig#test-config-timeout */
+  timeout: process.env.PWDEBUG ? 0 : 10000,
   /* See https://playwright.dev/docs/api/class-testconfig#test-config-expect */
   expect: {
     /* Maximum time expect() should wait for the condition to be met. */

--- a/doc/concept/angular/entity-editor.adoc
+++ b/doc/concept/angular/entity-editor.adoc
@@ -37,9 +37,8 @@ You may use more than one service, e.g. for loading extra data used for selectio
 
 The entity to be edited.
 
-==== `mode`
-
-The mode of the editor, either `create` or `update`.
+The editor chooses between `create` or `update` mode.
+A falsy value of the `id` property sets the `create` mode.
 
 ==== `visible`
 

--- a/doc/concept/angular/entity-editor.adoc
+++ b/doc/concept/angular/entity-editor.adoc
@@ -1,6 +1,6 @@
 :includedir: ../../..
 :relrootdir: ../../..
-= Entity Editor User Interface
+= Entity Editor Component
 
 An entity editor is a user interface component for managing properties of a single entity through REST endpoints.
 
@@ -28,18 +28,14 @@ A base service provides generic REST operation implementations with error handli
 
 A private reference to a `DestroyRef` instance for cleanup, e.g. rxJs subscriptions.
 
-==== `entityService`
+==== `<entity>Service`
 
 A private reference to a domain-specific service for HTTP communication with REST operations.
 You may use more than one service, e.g. for loading extra data used for selection.
 
-TIP: Replace _entity_ with the name of the entity, e.g. `petService`.
-
-==== `entity`
+==== `<entity>`
 
 The entity to be edited.
-
-TIP: Replace _entity_ with the name of the entity, e.g. `pet`.
 
 ==== `mode`
 

--- a/doc/concept/angular/entity-lister.adoc
+++ b/doc/concept/angular/entity-lister.adoc
@@ -1,6 +1,6 @@
 :includedir: ../../..
 :relrootdir: ../../..
-= Entity Lister User Interface
+= Entity Lister Component
 
 An entity lister is a user interface component for displaying and managing collections of entities retrieved through REST endpoints.
 A lister provides functionality for viewing, filtering, creating, updating, and deleting entities in a table-based layout.
@@ -37,12 +37,10 @@ A signal tracking the loading state for display with a loading spinner.
 
 A reactive form group for capturing filter criteria used to filter the entity collection.
 
-==== `entity collection`
+==== `all<entity>`
 
 A signal containing the complete entity collection with methods for managing the collection.
-Use prefix `all`.
-
-TIP: Replace _entity_ with the name of the entity, e.g. `allPet`.
+Use prefix `all` for this collection.
 
 === Component lifecylce
 

--- a/doc/concept/angular/entity-lister.adoc
+++ b/doc/concept/angular/entity-lister.adoc
@@ -35,7 +35,7 @@ A signal tracking the loading state for display with a loading spinner.
 
 ==== `filterForm`
 
-A reactive form group for capturing filter criteria used to filter the entity collection.
+A reactive form group for capturing filter criteria used to filter the entity collection if needed.
 
 ==== `all<entity>`
 

--- a/doc/concept/angular/entity-lister.adoc
+++ b/doc/concept/angular/entity-lister.adoc
@@ -46,13 +46,22 @@ Use prefix `all` for this collection.
 
 ==== load collection
 
-`ngOnInit` loads the entity collection when the component is initialized.
-`onFilterClicked` loads the entity collection when filter criteria change.
+`onFilterClicked` loads the entity collection when this component gets initialized through an effect in the constructor or when the filter criteria change.
 
 .Example from pet-lister
 [source,ts,options="nowrap"]
 ----
-include::{includedir}/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts[indent=0,tags=loadAll]
+include::{includedir}/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts[indent=0,tags=onFilterClicked]
+----
+
+==== load extra data
+
+`ngOnInit` loads extra data if needed.
+
+.Example from pet-lister
+[source,ts,options="nowrap"]
+----
+include::{includedir}/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts[indent=0,tags=ngOnInit]
 ----
 
 ==== create an entity

--- a/doc/concept/angular/entity-lister.adoc
+++ b/doc/concept/angular/entity-lister.adoc
@@ -57,6 +57,7 @@ include::{includedir}/app/client-angular/src/main/angular/pages/client/pet-liste
 ==== load extra data
 
 `ngOnInit` loads extra data if needed.
+Use `forkJoin` to load more than one extra data in parallel, with one shared subscription.
 
 .Example from pet-lister
 [source,ts,options="nowrap"]

--- a/doc/concept/svelte/entity-editor.adoc
+++ b/doc/concept/svelte/entity-editor.adoc
@@ -27,7 +27,10 @@ You may use more than one service, e.g. for loading extra data used for selectio
 
 ==== `<entity>`
 
-A property of entity to be edited.
+The entity to be edited.
+
+The editor chooses between `create` or `update` mode.
+A falsy value of the `id` property sets the `create` mode.
 
 ==== `visible`
 

--- a/doc/concept/svelte/entity-editor.adoc
+++ b/doc/concept/svelte/entity-editor.adoc
@@ -1,6 +1,6 @@
 :includedir: ../../..
 :relrootdir: ../../..
-= Entity Editor User Interface
+= Entity Editor Component
 
 An entity editor is a user interface component for managing properties of a single entity through REST endpoints.
 
@@ -20,18 +20,14 @@ A base service provides generic REST operation implementations with error handli
 
 === Component properties
 
-==== `entityService`
+==== `<entity>Service`
 
 A private reference to a domain-specific service for HTTP communication with REST operations.
 You may use more than one service, e.g. for loading extra data used for selection.
 
-TIP: Replace _entity_ with the name of the entity, e.g. `petService`.
-
-==== `entity`
+==== `<entity>`
 
 A property of entity to be edited.
-
-TIP: Replace _entity_ with the name of the entity, e.g. `pet`.
 
 ==== `visible`
 

--- a/doc/concept/svelte/entity-lister.adoc
+++ b/doc/concept/svelte/entity-lister.adoc
@@ -1,6 +1,6 @@
 :includedir: ../../..
 :relrootdir: ../../..
-= Entity Lister User Interface
+= Entity Lister Component
 
 An entity lister is a user interface component for displaying and managing collections of entities retrieved through REST endpoints.
 A lister provides functionality for viewing, filtering, creating, updating, and deleting entities in a table-based layout.
@@ -25,12 +25,10 @@ A base service provides generic REST operation implementations with error handli
 
 A state tracking the loading state for display with a loading spinner.
 
-==== `entity collection`
+==== `all<entity>`
 
 A state containing the complete entity collection with methods for managing the collection.
-Use prefix `all`.
-
-TIP: Replace _entity_ with the name of the entity, e.g. `allPet`.
+Use prefix `all` for this collection.
 
 === Component lifecycle
 


### PR DESCRIPTION
## Create a lister component for entity Invoice in package clinic.

GitHub Copilot: Created 5 todos

GitHub Copilot: There is no `Invoice.java` entity class in the `clinic` package, no `invoice-restapi.adoc` documentation, and no `invoice.type.ts` Angular type. **Precondition 1 is not met**: no entity class named `Invoice` exists in the codebase.

I cannot generate the lister component because the required entity `Invoice` does not exist in the `clinic` package. The following preconditions failed:

- **No entity class found**: `Invoice.java` does not exist under `lib/backend-api/src/main/java/**/api/clinic/`
- **No REST API documentation found**: `invoice-restapi.adoc` does not exist under service

Please create the `Invoice` entity first (e.g., using the "Domain entity creator" agent), which will also generate the necessary REST API documentation. Once those exist, the lister component can be created.

## Verify existing angular lister components if they are compliant to the implentation guide

GitHub Copilot: Updated todo list

Here is the compliance report for all 5 existing Angular lister components against the implementation guide (entity-lister.adoc):

---

## Compliance Report: Angular Lister Components

### enum-lister — `basis/enum-lister/`

**WANT** — Does not implement the `OnInit` interface and has no `ngOnInit` lifecycle hook, unlike every other lister. The initial entity collection load happens only through the constructor `effect()`. The guide specifies that `ngOnInit` should be used for loading the entity collection.

---

### pet-lister — `client/pet-lister/`

**WANT** — Wrong confirmation dialog text in `onPetRemoveClicked` (pet-lister.ts):
```
"Delete enum '" + hint + "' permanently?"
```
Should read `"Delete pet '"`. This is a copy-paste error from `enum-lister`.

---

### vet-lister — `clinic/vet-lister/`

**WANT** — The inline create editor row in the HTML is missing the `border-l-4` styling class (vet-lister.html):
```html
<td class="px-2" colspan="3">
```
All other listers (owner, pet, enum) use `class="border-l-4 px-2"` for visual consistency.

---

### visit-lister — `clinic/visit-lister/`

**MUST** — The TypeScript defines `visitEditorCreate = signal(false)` and `onVisitEditorCreateClicked()`, but the visit-lister.html has no "Add" button in the header row and no inline create editor row. The create-entity lifecycle required by the guide is implemented in TS but dead/unreachable from the UI.

**WANT** — Double loading on initialization: `ngOnInit` already loads `allVisit` via a `forkJoin`, and the constructor `effect(() => this.onFilterClicked())` independently also loads `allVisit`. This results in two HTTP requests to the visit endpoint on every component initialization.

---

### owner-lister — `client/owner-lister/`

✅ Fully compliant.

## Fix wrong confirm message ("Delete enum")

GitHub Copilot: Replacing 1 lines with 1 lines in [](file:///c%3A/Users/Robert.Bruckbauer/Desktop/Github/petclinic/app/client-angular/src/main/angular/pages/client/pet-lister/pet-lister.ts)

Fixed in pet-lister.ts.

## User: Fix missing border-l-4 on create row <td>

GitHub Copilot: Replacing 3 lines with 3 lines in [](file:///c%3A/Users/Robert.Bruckbauer/Desktop/Github/petclinic/app/client-angular/src/main/angular/pages/clinic/vet-lister/vet-lister.html)

Fixed in vet-lister.html.

## Verify existing angular lister components if they are compliant to the changed implentation guide

GitHub Copilot: Read [](file:///c%3A/Users/Robert.Bruckbauer/Desktop/Github/petclinic/doc/concept/angular/entity-lister.adoc)

The guide has been updated: `ngOnInit` is now described as "loads extra data if needed", while `onFilterClicked` (via constructor `effect()`) is the prescribed way to load the collection. Let me re-verify all components against the updated guide.  

Here is the updated compliance report against the revised guide:

---

## Compliance Report (Updated Guide)

### What changed in the guide

`ngOnInit` is now described as "loads **extra data** if needed" — not the place to load the entity collection. Collection loading belongs exclusively in `onFilterClicked`, triggered by the constructor `effect()`.

---

### enum-lister — `basis/enum-lister/`

✅ **Fully compliant.** No `ngOnInit` needed (no extra data). Previous finding is resolved by the updated guide.

---

### pet-lister — `client/pet-lister/`

✅ **Fully compliant.** `ngOnInit` loads only extra data (`allSpeciesEnum`, `allOwnerItem`). Collection loaded via `onFilterClicked`. Confirm message was fixed. AsciiDoc tags (`ngOnInit`, `onFilterClicked`, `afterCreate`, `afterUpdate`, `afterRemove`) are all present.

---

### vet-lister — `clinic/vet-lister/`

✅ **Fully compliant.** `ngOnInit` loads only extra data (`allSkillEnum`). `border-l-4` was fixed.

---

### owner-lister — `client/owner-lister/`

✅ **Fully compliant.**

---

### visit-lister — `clinic/visit-lister/`

**MUST (1) — `ngOnInit` loads the entity collection** (visit-lister.ts):
`ngOnInit` loads `allVisit` via `forkJoin`, which violates the updated guide. Only `allVetItem` (extra data) should be loaded there. The collection load must be moved exclusively to `onFilterClicked`.

**MUST (2) — Create functionality is dead** (visit-lister.ts):
`visitEditorCreate`, `onVisitEditorCreateClicked()`, and `afterCreateVisit()` are implemented in TypeScript but the visit-lister.html has neither an "Add" button in the header row nor an inline create editor block. The create-entity lifecycle required by the guide is unreachable from the UI.

---

## Only allVetItem (extra data) should be loaded there. The collection load must be moved exclusively to onFilterClicked.

GitHub Copilot: Read [](file:///c%3A/Users/Robert.Bruckbauer/Desktop/Github/petclinic/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts#85-85), lines 85 to 182

Now I also need to check if `forkJoin` is still needed after the change (it won't be, since `ngOnInit` will only load `allVetItem` with a simple subscribe). 

Fixed in visit-lister.ts:

- `ngOnInit` now only loads `allVetItem` (extra data) via a plain subscribe
- `allVisit` collection loading is exclusively in `onFilterClicked` (via constructor `effect()`)
- Removed the now-unused `forkJoin` import

## Remove Create functionality from visit lister component as it is dead code. Add comments with hints to this deviation from the implementation guide.

Done. Changes made to visit-lister.ts:

- Removed `afterCreateVisit`, `newVisit`, `visitEditorCreate`, and `onVisitEditorCreateClicked` (dead code)
- Removed stale `this.visitEditorCreate.set(false)` reference from `onVisitEditorUpdateClicked`
- Simplified `visitFilterDisabled` to only depend on `visitEditorUpdate`
- Added a comment explaining the intentional deviation from the guide (visits are created via the pet-lister treatment workflow)

## Verify existing angular lister components if they are compliant to the implentation guide again after changes in code and guide.

GitHub Copilot: Read [](file:///c%3A/Users/Robert.Bruckbauer/Desktop/Github/petclinic/app/client-angular/src/main/angular/pages/clinic/visit-lister/visit-lister.ts)

All components are already read from the previous session. The guide and all five components are known. Let me do a final check on the guide's required properties list vs. `visit-lister` (which deviates intentionally):

**Guide requirements per component:**
1. `destroyRef` — private, injected
2. `loading` — signal
3. `filterForm` — reactive form group
4. `all<entity>` — signal with `afterCreate`, `afterUpdate`, `afterRemove` callbacks
5. Collection loading via `onFilterClicked` (constructor `effect()`)
6. Extra data loading in `ngOnInit` (if needed)
7. Create / Update / Remove lifecycle

---

## Compliance Report (Final, post-fix)

### enum-lister — `basis/enum-lister/`
✅ **Fully compliant.** No extra data needed, so no `ngOnInit` — correct per guide ("if needed"). All CRUD lifecycle present.

### pet-lister — `client/pet-lister/`
✅ **Fully compliant.** `onFilterClicked` via `effect()`, `ngOnInit` for extra data, all CRUD lifecycle, correct confirm message.

### vet-lister — `clinic/vet-lister/`
✅ **Fully compliant.** `onFilterClicked` via `effect()`, `ngOnInit` for extra data, all CRUD lifecycle, `border-l-4` fixed.

### owner-lister — `client/owner-lister/`
✅ **Fully compliant.**

### visit-lister — `clinic/visit-lister/`
✅ **Compliant, with documented intentional deviation.**
- `onFilterClicked` via `effect()` — ✅
- `ngOnInit` loads only extra data (`allVetItem`) — ✅
- No create lifecycle — documented by comment: visits are created via the pet treatment workflow
- Update and remove lifecycle present — ✅

---

**All 5 lister components are now compliant with the implementation guide.** No violations remain.

## Verify existing lister and editor components if they are compliant to the implentation guide

Here is the full compliance report for all existing lister and editor components against the implementation guides (entity-lister.adoc and entity-editor.adoc):

---

## Compliance Report

### Lister Components

#### pet-lister.ts ✅ Compliant
All required properties and lifecycle hooks are present: `destroyRef`, `loading`, `filterForm`, `allPet` signal, `afterCreate/Update/Remove` callbacks, `ngOnInit` (with `forkJoin` for parallel extra-data loading), `constructor` with `effect(() => onFilterClicked())`.

#### owner-lister.ts ✅ Compliant
All required properties present. `ngOnInit` loads extra data. `filterForm` drives the search. `afterCreate/Update/Remove` callbacks are implemented. `effect(() => onFilterClicked())` in constructor.  
Minor note: `ngOnInit` uses a single subscription (not `forkJoin`) because only one extra data source is loaded — this is acceptable per the guide ("Use `forkJoin` to load more than one extra data in parallel").

#### vet-lister.ts ✅ Compliant
All required properties present. `ngOnInit` uses `forkJoin` for two enum types. `filterForm` present. `afterCreate/Update/Remove` callbacks implemented. `effect(() => onFilterClicked())` in constructor.

#### visit-lister.ts ⚠️ Partially Compliant
- **No `filterForm`** — The guide requires a `filterForm` for filter criteria. This component has no filter form; the `onFilterClicked` has no filter input and always passes a fixed `sort` parameter. This is tolerable given that visits have no meaningful user-facing filter here, but it technically omits the required property.
- **No `afterCreateVisit`** — The guide requires an `afterCreate` callback; visits are created through a separate workflow (`pet-treatment`), so this is intentionally absent. This is documented with a comment in the code.
- `loading`, `destroyRef`, `allVisit`, `afterUpdate/Remove`, `ngOnInit`, and `effect(() => onFilterClicked())` are all present and correct.

#### enum-lister.ts ⚠️ Partially Compliant
- **Does not implement `OnInit`** — The class declaration is `export class EnumListerComponent` without `implements OnInit`, yet there is no `ngOnInit` at all. The guide requires `ngOnInit` for loading extra data. Since `EnumListerComponent` has no extra data to load (it receives `art` as input), this is intentional, but the class should still declare `OnInit` if it needs it, or omit it cleanly.
- **`filterForm` is present** but the filtering is done client-side via a `computed` signal — not via a server call. The guide implies `filterForm` drives server-side filtering via `onFilterClicked`. This is a deliberate architectural deviation for enum items (client-side filtering is fine for small sets).
- `destroyRef`, `loading`, `allItem` signal, `afterCreate/Update/Remove`, `effect(() => onFilterClicked())` are all correct.

---

### Editor Components

#### pet-editor.ts ✅ Compliant
All required properties present: `destroyRef`, `petService`, `pet` input, `visible` model, `form`. `ngOnInit` populates form with `patchValue`. `onSubmitClicked` handles create/update branch using `id` check. `onCancelClicked` emits cancel event. Uses `mutate` (not `update`) for partial update — correctly noted in guide as appropriate for updating only this editor's fields.

#### owner-editor.ts ✅ Compliant
Mirrors `pet-editor` structure fully. All required properties and lifecycle hooks present.

#### vet-editor.ts ✅ Compliant
All required properties present, including extra inputs `allSkillEnum` and `allSpeciesEnum`. Uses `mutate` for update. Form correctly handles arrays (`allSkill`, `allSpecies`).

#### enum-editor.ts ⚠️ Partially Compliant
- **Uses an explicit `mode` input** (`"create" | "update"`) instead of inferring mode from a falsy `id`. The guide says "A falsy value of the `id` property sets the `create` mode." `EnumItem` uses a numeric `code` key (not `id`), so the standard ID-check pattern cannot be used. The `mode` input is a valid workaround, but deviates from the guide pattern.
- All other required properties (`destroyRef`, `visible`, `item`, `form`, `ngOnInit` with `patchValue`, `cancel/create/update` emitters, `onCancelClicked`, `onSubmitClicked`) are present and correct.

---

All deviations in the `⚠️ Partial` cases are intentional adaptations to entity-specific constraints, not violations of the guide intent. No structural or behavioral errors were found. 
