### PR TITLE
feat: DatabaseCleaner für REST API Tests

### DIFF
--- a/.github/agents/domain-add-collection.agent.md
+++ b/.github/agents/domain-add-collection.agent.md
@@ -78,6 +78,7 @@ You MUST NOT generate code if even one of the preconditions is not met.
 
 9. **Update REST API test <Entity>RestApiTest.java**
   Use doc/concept/spring/endpoint.adoc as the implementation baseline.
+  Add `DELETE` statement for database table <entity>_<name> in DatabaseCleaner.java.
   If collection is mandatory update existing test data with a default value.
   Update existing tests with asserts for the new collection.
   Add `patchApi<Entity><Name>` test.

--- a/.github/agents/domain-create-entity.agent.md
+++ b/.github/agents/domain-create-entity.agent.md
@@ -60,6 +60,7 @@ You MUST NOT generate code if even one of the preconditions is not met.
 
 8. **Create REST API test <Entity>RestApiTest.java**
   Use `doc/concept/spring/_json-jpa-rest-controller.adoc` as the implementation baseline.
+  Add `DELETE` statement for database table <entity> in DatabaseCleaner.java.
 
 9. **Create GraphQL schema <entity>.gqls**
   Use `doc/concept/spring/_graphql-controller.adoc` as the implementation baseline.

--- a/doc/concept/spring/_json-jpa-rest-controller.adoc
+++ b/doc/concept/spring/_json-jpa-rest-controller.adoc
@@ -239,6 +239,9 @@ class <Entity>RestApiTest {
     private MockMvc mockMvc;
 
     @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @Autowired
     private <Entity>Repository <entity>Repository;
 
     @BeforeEach <1>
@@ -442,10 +445,8 @@ class <Entity>RestApiTest {
 
     @Test <11>
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertDoesNotThrow(() -> <entity>Repository.deleteAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }
 ----
@@ -460,4 +461,4 @@ class <Entity>RestApiTest {
 <8> Test for the error path of a GET operation when the entity does not exist.
 <9> Test for the happy path of a DELETE operation.
 <10> Test for the error path of a DELETE operation when the entity does not exist.
-<11> Empty all touched tables.
+<11> Empty all entity tables.

--- a/lib/backend-data/src/test/java/esy/app/DatabaseCleaner.java
+++ b/lib/backend-data/src/test/java/esy/app/DatabaseCleaner.java
@@ -1,0 +1,32 @@
+package esy.app;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+
+@Component
+public class DatabaseCleaner {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DatabaseCleaner(final DataSource dataSource) {
+        this.jdbcTemplate = new JdbcTemplate(dataSource);
+    }
+
+    /**
+     * Truncates all entity tables in the correct foreign-key order.
+     */
+    @Transactional
+    public void cleanDatabase() {
+        jdbcTemplate.execute("DELETE FROM visit");
+        jdbcTemplate.execute("DELETE FROM vet_skill");
+        jdbcTemplate.execute("DELETE FROM vet_species");
+        jdbcTemplate.execute("DELETE FROM vet");
+        jdbcTemplate.execute("DELETE FROM pet");
+        jdbcTemplate.execute("DELETE FROM owner");
+        jdbcTemplate.execute("DELETE FROM enum");
+        jdbcTemplate.execute("DELETE FROM ping");
+    }
+}

--- a/lib/backend-data/src/test/java/esy/app/basis/EnumRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/basis/EnumRestApiTest.java
@@ -1,5 +1,6 @@
 package esy.app.basis;
 
+import esy.app.DatabaseCleaner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -11,13 +12,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -38,7 +37,7 @@ class EnumRestApiTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private EnumRepository enumRepository;
+    private DatabaseCleaner databaseCleaner;
 
     @BeforeEach
     void setUp(final WebApplicationContext webApplicationContext,
@@ -260,12 +259,7 @@ class EnumRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertEquals(2, enumRepository.count(ENUM_ART));
-        enumRepository.findAll(ENUM_ART).forEach(e ->
-                enumRepository.delete(e));
-        enumRepository.deleteAll();
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }

--- a/lib/backend-data/src/test/java/esy/app/basis/PingRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/basis/PingRestApiTest.java
@@ -1,5 +1,6 @@
 package esy.app.basis;
 
+import esy.app.DatabaseCleaner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -9,15 +10,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
@@ -36,7 +35,7 @@ class PingRestApiTest {
     private MockMvc mockMvc;
 
     @Autowired
-    private PingRepository pingRepository;
+    private DatabaseCleaner databaseCleaner;
 
     @BeforeEach
     void setUp(final WebApplicationContext webApplicationContext,
@@ -133,10 +132,7 @@ class PingRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertEquals(1, pingRepository.count());
-        pingRepository.deleteAll(pingRepository.findAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }

--- a/lib/backend-data/src/test/java/esy/app/client/OwnerRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/client/OwnerRestApiTest.java
@@ -1,6 +1,7 @@
 package esy.app.client;
 
 import esy.api.client.QOwner;
+import esy.app.DatabaseCleaner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,10 +13,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.UUID;
@@ -37,6 +36,9 @@ class OwnerRestApiTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
 
     @Autowired
     private OwnerRepository ownerRepository;
@@ -398,9 +400,7 @@ class OwnerRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertDoesNotThrow(() -> ownerRepository.deleteAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }

--- a/lib/backend-data/src/test/java/esy/app/client/PetRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/client/PetRestApiTest.java
@@ -1,6 +1,7 @@
 package esy.app.client;
 
 import esy.api.client.QPet;
+import esy.app.DatabaseCleaner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,11 +13,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.UUID;
@@ -38,6 +37,9 @@ class PetRestApiTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
 
     @Autowired
     private OwnerRepository ownerRepository;
@@ -511,10 +513,7 @@ class PetRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertDoesNotThrow(() -> petRepository.deleteAll());
-        assertDoesNotThrow(() -> ownerRepository.deleteAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }

--- a/lib/backend-data/src/test/java/esy/app/clinic/VetRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VetRestApiTest.java
@@ -1,6 +1,7 @@
 package esy.app.clinic;
 
 import esy.api.clinic.QVet;
+import esy.app.DatabaseCleaner;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -12,10 +13,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.util.UUID;
@@ -37,6 +36,9 @@ class VetRestApiTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
 
     @Autowired
     private VetRepository vetRepository;
@@ -412,9 +414,7 @@ class VetRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertDoesNotThrow(() -> vetRepository.deleteAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
@@ -1,6 +1,7 @@
 package esy.app.clinic;
 
 import esy.api.clinic.Visit;
+import esy.app.DatabaseCleaner;
 import esy.app.client.OwnerRepository;
 import esy.app.client.PetRepository;
 import org.junit.jupiter.api.*;
@@ -14,11 +15,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.WebApplicationContext;
 
 import java.time.LocalDate;
@@ -42,6 +41,9 @@ class VisitRestApiTest {
 
     @Autowired
     private MockMvc mockMvc;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
 
     @Autowired
     private OwnerRepository ownerRepository;
@@ -646,12 +648,7 @@ class VisitRestApiTest {
 
     @Test
     @Order(999)
-    @Transactional
-    @Rollback(false)
     void cleanup() {
-        assertDoesNotThrow(() -> visitRepository.deleteAll());
-        assertDoesNotThrow(() -> vetRepository.deleteAll());
-        assertDoesNotThrow(() -> petRepository.deleteAll());
-        assertDoesNotThrow(() -> ownerRepository.deleteAll());
+        assertDoesNotThrow(databaseCleaner::cleanDatabase);
     }
 }


### PR DESCRIPTION
```
Create a java class DatabaseCleaner. implement a cleanDatabase method that truncates all tables for entities. Use JDBC directly. make it a spring component to inject it in RestApiTest. Use the cleanDatabase method in the cleanup methode of all existing test classes instead the existing individual repository operations.
```

