### PR TITLE
build: Coverage mit v8 für Angular und Svelte

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           gradle build --parallel
 
       - name: Build Reports
-        run: gradle coverageTestReport jacocoTestReport
+        run: gradle coverageTestReport
 
       - name: Build Pages
         run: gradle pages

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
 
       # https://github.com/gradle/actions
       # tag::setup-gradle[]
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v6
         with:
           gradle-version: "8.14"
       # end::setup-gradle[]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
           gradle build --parallel
 
       - name: Build Reports
-        run: gradle jacocoTestReport
+        run: gradle coverageTestReport jacocoTestReport
 
       - name: Build Pages
         run: gradle pages

--- a/app/client-angular/build.gradle
+++ b/app/client-angular/build.gradle
@@ -26,6 +26,8 @@ tasks.register('npmBuild', NpmTask) {
     mustRunAfter 'npmInstall'
     // https://docs.npmjs.com/cli/v10/commands/npm-run-script
     npmCommand = ['run', 'build']
+    inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.html'))
+    inputs.file('package.json')
 }
 
 check {
@@ -40,7 +42,7 @@ tasks.register('npmCheck', NpmTask) {
     npmCommand = ['run', 'test']
     inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.html'))
     inputs.file('package.json')
-    outputs.file(layout.buildDirectory.file('npmCheck.stamp'))
+    outputs.dir(layout.buildDirectory.dir('test-results/test'))
 }
 
 tasks.register('npmCoverage', NpmTask) {

--- a/app/client-angular/build.gradle
+++ b/app/client-angular/build.gradle
@@ -40,6 +40,22 @@ tasks.register('npmCheck', NpmTask) {
     npmCommand = ['run', 'test']
 }
 
+tasks.register('npmCoverage', NpmTask) {
+    group = 'verification'
+    // No node in CI-Job build-java
+    onlyIf { System.env['CI'] == null }
+    mustRunAfter 'npmInstall'
+    // https://docs.npmjs.com/cli/v10/commands/npm-run-script
+    npmCommand = ['run', 'coverage']
+}
+
+tasks.register('coverageTestReport', Copy) {
+    group = 'verification'
+    dependsOn 'npmCoverage'
+    from layout.buildDirectory.dir('coverage')
+    into rootProject.layout.projectDirectory.dir('pages/html/' + project.name + '/coverage')
+}
+
 import java.util.Optional;
 ext.CLIENT_NAME = Optional.ofNullable(System.getenv("CLIENT_NAME"))
         .orElse(rootProject.name + "-" + project.name)

--- a/app/client-angular/build.gradle
+++ b/app/client-angular/build.gradle
@@ -38,6 +38,9 @@ tasks.register('npmCheck', NpmTask) {
     mustRunAfter 'npmInstall'
     // https://docs.npmjs.com/cli/v10/commands/npm-run-script
     npmCommand = ['run', 'test']
+    inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.html'))
+    inputs.file('package.json')
+    outputs.file(layout.buildDirectory.file('npmCheck.stamp'))
 }
 
 tasks.register('npmCoverage', NpmTask) {

--- a/app/client-angular/build.npm.sh
+++ b/app/client-angular/build.npm.sh
@@ -2,4 +2,4 @@
 dir=$(dirname "$0")
 cd $dir
 cmd=${1:-install}
-npm $cmd && npm run prettierCheck && npm run build && npm run test
+npm $cmd && npm run prettierCheck && npm run build && npm run test && npm run coverage

--- a/app/client-angular/package-lock.json
+++ b/app/client-angular/package-lock.json
@@ -25,6 +25,7 @@
         "@angular/cli": "21.2.5",
         "@angular/compiler-cli": "21.2.6",
         "@playwright/test": "1.58.2",
+        "@vitest/coverage-v8": "4.1.2",
         "chance": "1.1.13",
         "daisyui": "5.5.19",
         "prettier": "3.8.1",
@@ -960,6 +961,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4145,6 +4156,37 @@
         "vite": "^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -4418,6 +4460,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -5679,6 +5740,16 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -5737,6 +5808,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "10.0.0",
@@ -6028,6 +6106,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/jiti": {
@@ -6509,6 +6616,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -8325,6 +8460,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tailwindcss": {

--- a/app/client-angular/package.json
+++ b/app/client-angular/package.json
@@ -6,6 +6,7 @@
     "build": "ng build",
     "start": "ng serve --port 5052",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "e2e": "npx playwright test",
     "e2e-headed": "npx playwright test --headed",
     "e2e-codegen": "npx playwright codegen localhost:5052",
@@ -36,6 +37,7 @@
     "daisyui": "5.5.19",
     "prettier": "3.8.1",
     "typescript": "5.9.3",
-    "vitest": "4.1.2"
+    "vitest": "4.1.2",
+    "@vitest/coverage-v8": "4.1.2"
   }
 }

--- a/app/client-angular/src/main/angular/services/enum.service.test.ts
+++ b/app/client-angular/src/main/angular/services/enum.service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { of } from "rxjs";
-import { EnumService } from "./enum.service";
+import { EnumService, filterByCriteria } from "./enum.service";
 import { type EnumItem } from "../types/enum.type";
 
 const ALLSPECIES: EnumItem[] = [
@@ -80,5 +80,41 @@ describe("EnumService", () => {
         },
       });
     });
+  });
+});
+
+describe("filterByCriteria", () => {
+  const item: EnumItem = {
+    code: 1,
+    name: "Dog",
+    text: "A dog is an animal of the species Canis lupus familiaris.",
+  };
+
+  it("should return true when criteria is null", () => {
+    expect(filterByCriteria(null)(item)).toBe(true);
+  });
+
+  it("should return true when criteria is undefined", () => {
+    expect(filterByCriteria(undefined)(item)).toBe(true);
+  });
+
+  it("should return true when criteria is empty string", () => {
+    expect(filterByCriteria("")(item)).toBe(true);
+  });
+
+  it("should return true when name matches criteria", () => {
+    expect(filterByCriteria("Dog")(item)).toBe(true);
+  });
+
+  it("should return true when name matches criteria case-insensitively", () => {
+    expect(filterByCriteria("dog")(item)).toBe(true);
+  });
+
+  it("should return true when text matches criteria", () => {
+    expect(filterByCriteria("A dog")(item)).toBe(true);
+  });
+
+  it("should return false when neither name nor text matches criteria", () => {
+    expect(filterByCriteria("Cat")(item)).toBe(false);
   });
 });

--- a/app/client-angular/src/main/angular/stores/owner.store.test.ts
+++ b/app/client-angular/src/main/angular/stores/owner.store.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// A real-storage-backed mock so getItem/setItem stay consistent within a test.
+// The internal store object is shared across all tests and cleared in beforeEach.
+const storageData: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storageData[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storageData[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete storageData[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(storageData).forEach((k) => delete storageData[k]);
+  }),
+};
+
+describe("owner.store", () => {
+  beforeEach(() => {
+    // Reset module registry so each test gets a fresh signal initialised
+    // with the current localStorage state.
+    vi.resetModules();
+    localStorageMock.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", localStorageMock);
+  });
+
+  describe("initialization", () => {
+    it("should use default payload when localStorage is empty", async () => {
+      const { getStoredOwner } = await import("./owner.store");
+
+      expect(getStoredOwner()).toEqual({ id: undefined });
+    });
+
+    it("should restore value from localStorage when a stored entry exists", async () => {
+      const stored = { id: "42" };
+      storageData["storedOwner"] = JSON.stringify(stored);
+
+      const { getStoredOwner } = await import("./owner.store");
+
+      expect(getStoredOwner()).toEqual(stored);
+    });
+
+    it("should fall back to default payload when localStorage contains null", async () => {
+      storageData["storedOwner"] = "null";
+
+      const { getStoredOwner } = await import("./owner.store");
+
+      expect(getStoredOwner()).toEqual({ id: undefined });
+    });
+  });
+
+  describe("persistence", () => {
+    it("should write to localStorage when setStoredOwner is called", async () => {
+      const { setStoredOwner } = await import("./owner.store");
+      vi.clearAllMocks();
+
+      setStoredOwner({ id: "99" });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "storedOwner",
+        JSON.stringify({ id: "99" })
+      );
+    });
+
+    it("should write to localStorage on every call to setStoredOwner", async () => {
+      const { setStoredOwner } = await import("./owner.store");
+      vi.clearAllMocks();
+
+      setStoredOwner({ id: "1" });
+      setStoredOwner({ id: "2" });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledTimes(2);
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+        "storedOwner",
+        JSON.stringify({ id: "2" })
+      );
+    });
+  });
+
+  describe("store value", () => {
+    it("should reflect new value after setStoredOwner", async () => {
+      const { getStoredOwner, setStoredOwner } = await import("./owner.store");
+
+      setStoredOwner({ id: "7" });
+
+      expect(getStoredOwner()).toEqual({ id: "7" });
+    });
+
+    it("should reflect successive updates", async () => {
+      const { getStoredOwner, setStoredOwner } = await import("./owner.store");
+
+      setStoredOwner({ id: "7" });
+      setStoredOwner({ id: "8" });
+
+      expect(getStoredOwner()).toEqual({ id: "8" });
+    });
+
+    it("should allow clearing the id", async () => {
+      storageData["storedOwner"] = JSON.stringify({ id: "5" });
+      const { getStoredOwner, setStoredOwner } = await import("./owner.store");
+
+      setStoredOwner({ id: undefined });
+
+      expect(getStoredOwner()).toEqual({ id: undefined });
+    });
+  });
+});

--- a/app/client-angular/vitest.config.ts
+++ b/app/client-angular/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
+      reporter: ["text", "html"],
       include: [
         "src/main/angular/services/*.ts",
         "src/main/angular/stores/*.ts",

--- a/app/client-angular/vitest.config.ts
+++ b/app/client-angular/vitest.config.ts
@@ -12,6 +12,14 @@ export default defineConfig({
     setupFiles: ['./vitest.setup.js'],
     typecheck: {
       enabled: true
+    },
+    coverage: {
+      provider: 'v8',
+      include: [
+        "src/main/angular/services/*.ts",
+        "src/main/angular/stores/*.ts",
+      ],
+      reportsDirectory: './build/coverage'
     }
   },
 })

--- a/app/client-svelte/build.gradle
+++ b/app/client-svelte/build.gradle
@@ -38,6 +38,9 @@ tasks.register('npmCheck', NpmTask) {
     mustRunAfter 'npmInstall'
     // https://docs.npmjs.com/cli/v10/commands/npm-run-script
     npmCommand = ['run', 'test']
+    inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.svelte'))
+    inputs.file('package.json')
+    outputs.file(layout.buildDirectory.file('npmCheck.stamp'))
 }
 
 tasks.register('npmCoverage', NpmTask) {

--- a/app/client-svelte/build.gradle
+++ b/app/client-svelte/build.gradle
@@ -40,6 +40,22 @@ tasks.register('npmCheck', NpmTask) {
     npmCommand = ['run', 'test']
 }
 
+tasks.register('npmCoverage', NpmTask) {
+    group = 'verification'
+    // No node in CI-Job build-java
+    onlyIf { System.env['CI'] == null }
+    mustRunAfter 'npmInstall'
+    // https://docs.npmjs.com/cli/v10/commands/npm-run-script
+    npmCommand = ['run', 'coverage']
+}
+
+tasks.register('coverageTestReport', Copy) {
+    group = 'verification'
+    dependsOn 'npmCoverage'
+    from layout.buildDirectory.dir('coverage')
+    into rootProject.layout.projectDirectory.dir('pages/html/' + project.name + '/coverage')
+}
+
 import java.util.Optional;
 ext.CLIENT_NAME = Optional.ofNullable(System.getenv("CLIENT_NAME"))
         .orElse(rootProject.name + "-" + project.name)

--- a/app/client-svelte/build.gradle
+++ b/app/client-svelte/build.gradle
@@ -26,6 +26,8 @@ tasks.register('npmBuild', NpmTask) {
     mustRunAfter 'npmInstall'
     // https://docs.npmjs.com/cli/v10/commands/npm-run-script
     npmCommand = ['run', 'build']
+    inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.svelte'))
+    inputs.file('package.json')
 }
 
 check {
@@ -40,7 +42,7 @@ tasks.register('npmCheck', NpmTask) {
     npmCommand = ['run', 'test']
     inputs.files(fileTree('src/main').include('**/*.ts', '**/*.js', '**/*.svelte'))
     inputs.file('package.json')
-    outputs.file(layout.buildDirectory.file('npmCheck.stamp'))
+    outputs.dir(layout.buildDirectory.dir('test-results/test'))
 }
 
 tasks.register('npmCoverage', NpmTask) {

--- a/app/client-svelte/build.npm.sh
+++ b/app/client-svelte/build.npm.sh
@@ -2,4 +2,4 @@
 dir=$(dirname "$0")
 cd $dir
 cmd=${1:-install}
-npm $cmd && npm run prettierCheck && npm run build && npm run test
+npm $cmd && npm run prettierCheck && npm run build && npm run test && npm run coverage

--- a/app/client-svelte/package-lock.json
+++ b/app/client-svelte/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/postcss": "4.2.2",
         "@tailwindcss/vite": "4.2.2",
         "@types/node": "24.12.0",
+        "@vitest/coverage-v8": "4.1.2",
         "chance": "1.1.13",
         "daisyui": "5.5.19",
         "dotenv": "17.3.1",
@@ -38,6 +39,66 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -509,9 +570,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1256,6 +1317,37 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.2",
+        "vitest": "4.1.2"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -1392,6 +1484,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1635,6 +1739,23 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -1645,6 +1766,45 @@
         "@types/estree": "^1.0.6"
       }
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -1653,6 +1813,13 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -1919,6 +2086,34 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -2116,6 +2311,19 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -2145,6 +2353,19 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/svelte": {
       "version": "5.55.1",
@@ -2510,6 +2731,43 @@
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true
     },
+    "@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true
+    },
+    "@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.29.0"
+      }
+    },
+    "@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      }
+    },
+    "@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true
+    },
     "@esbuild/aix-ppc64": {
       "version": "0.27.1",
       "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.1.tgz",
@@ -2732,9 +2990,9 @@
       "dev": true
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3175,6 +3433,24 @@
       "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
       "dev": true
     },
+    "@vitest/coverage-v8": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.2.tgz",
+      "integrity": "sha512-sPK//PHO+kAkScb8XITeB1bf7fsk85Km7+rt4eeuRR3VS1/crD47cmV5wicisJmjNdfeokTZwjMk4Mj2d58Mgg==",
+      "dev": true,
+      "requires": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.2",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      }
+    },
     "@vitest/expect": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
@@ -3265,6 +3541,17 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true
+    },
+    "ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
     },
     "axobject-query": {
       "version": "4.1.0",
@@ -3436,6 +3723,18 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -3445,10 +3744,43 @@
         "@types/estree": "^1.0.6"
       }
     },
+    "istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
     "jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true
     },
     "lightningcss": {
@@ -3561,6 +3893,26 @@
       "dev": true,
       "requires": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "requires": {
+        "semver": "^7.5.3"
       }
     },
     "ms": {
@@ -3678,6 +4030,12 @@
         "tslib": "^2.1.0"
       }
     },
+    "semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true
+    },
     "siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -3701,6 +4059,15 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
     },
     "svelte": {
       "version": "5.55.1",

--- a/app/client-svelte/package.json
+++ b/app/client-svelte/package.json
@@ -5,6 +5,7 @@
     "build": "vite build",
     "start": "vite serve --port 5050",
     "test": "vitest run",
+    "coverage": "vitest run --coverage",
     "e2e": "npx playwright test",
     "e2e-headed": "npx playwright test --headed",
     "e2e-codegen": "npx playwright codegen localhost:5050",
@@ -29,7 +30,8 @@
     "typescript": "5.9.3",
     "uuid": "13.0.0",
     "vite": "7.3.1",
-    "vitest": "4.1.2"
+    "vitest": "4.1.2",
+    "@vitest/coverage-v8": "4.1.2"
   },
   "type": "module"
 }

--- a/app/client-svelte/src/main/svelte/services/enum.service.test.ts
+++ b/app/client-svelte/src/main/svelte/services/enum.service.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { EnumService } from "./enum.service";
+import { EnumService, filterByCriteria } from "./enum.service";
 import { type EnumItem } from "../types/enum.type";
 
 const ALLSPECIES: EnumItem[] = [
@@ -95,5 +95,41 @@ describe("EnumService", () => {
         },
       });
     });
+  });
+});
+
+describe("filterByCriteria", () => {
+  const item: EnumItem = {
+    code: 1,
+    name: "Dog",
+    text: "A dog is an animal of the species Canis lupus familiaris.",
+  };
+
+  it("should return true when criteria is null", () => {
+    expect(filterByCriteria(null)(item)).toBe(true);
+  });
+
+  it("should return true when criteria is undefined", () => {
+    expect(filterByCriteria(undefined)(item)).toBe(true);
+  });
+
+  it("should return true when criteria is empty string", () => {
+    expect(filterByCriteria("")(item)).toBe(true);
+  });
+
+  it("should return true when name matches criteria", () => {
+    expect(filterByCriteria("Dog")(item)).toBe(true);
+  });
+
+  it("should return true when name matches criteria case-insensitively", () => {
+    expect(filterByCriteria("dog")(item)).toBe(true);
+  });
+
+  it("should return true when text matches criteria", () => {
+    expect(filterByCriteria("A dog")(item)).toBe(true);
+  });
+
+  it("should return false when neither name nor text matches criteria", () => {
+    expect(filterByCriteria("Cat")(item)).toBe(false);
   });
 });

--- a/app/client-svelte/src/main/svelte/stores/owner.store.test.ts
+++ b/app/client-svelte/src/main/svelte/stores/owner.store.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { get } from "svelte/store";
+
+// A real-storage-backed mock so getItem/setItem stay consistent within a test.
+// The internal `store` object is shared across all tests and cleared in beforeEach.
+const storageData: Record<string, string> = {};
+
+const localStorageMock = {
+  getItem: vi.fn((key: string) => storageData[key] ?? null),
+  setItem: vi.fn((key: string, value: string) => {
+    storageData[key] = value;
+  }),
+  removeItem: vi.fn((key: string) => {
+    delete storageData[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(storageData).forEach((k) => delete storageData[k]);
+  }),
+};
+
+describe("owner.store", () => {
+  beforeEach(() => {
+    // Reset module registry so each test gets a fresh store initialised
+    // with the current localStorage state — same pattern as router.test.ts.
+    vi.resetModules();
+    localStorageMock.clear();
+    vi.clearAllMocks();
+    vi.stubGlobal("localStorage", localStorageMock);
+  });
+
+  describe("initialization", () => {
+    it("should use default payload when localStorage is empty", async () => {
+      const { storedOwner } = await import("./owner.store");
+
+      expect(get(storedOwner)).toEqual({ id: undefined });
+    });
+
+    it("should restore value from localStorage when a stored entry exists", async () => {
+      const stored = { id: "42" };
+      storageData["storedOwner"] = JSON.stringify(stored);
+
+      const { storedOwner } = await import("./owner.store");
+
+      expect(get(storedOwner)).toEqual(stored);
+    });
+
+    it("should fall back to default payload when localStorage contains null", async () => {
+      storageData["storedOwner"] = "null";
+
+      const { storedOwner } = await import("./owner.store");
+
+      expect(get(storedOwner)).toEqual({ id: undefined });
+    });
+  });
+
+  describe("persistence", () => {
+    it("should write to localStorage when value is set", async () => {
+      const { storedOwner } = await import("./owner.store");
+      vi.clearAllMocks(); // ignore the initial subscribe write
+
+      storedOwner.set({ id: "99" });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "storedOwner",
+        JSON.stringify({ id: "99" })
+      );
+    });
+
+    it("should write to localStorage when value is updated", async () => {
+      const { storedOwner } = await import("./owner.store");
+      vi.clearAllMocks();
+
+      storedOwner.update((current) => ({ ...current, id: "123" }));
+
+      expect(localStorageMock.setItem).toHaveBeenCalledWith(
+        "storedOwner",
+        JSON.stringify({ id: "123" })
+      );
+    });
+
+    it("should write to localStorage on every change", async () => {
+      const { storedOwner } = await import("./owner.store");
+      vi.clearAllMocks();
+
+      storedOwner.set({ id: "1" });
+      storedOwner.set({ id: "2" });
+
+      expect(localStorageMock.setItem).toHaveBeenCalledTimes(2);
+      expect(localStorageMock.setItem).toHaveBeenLastCalledWith(
+        "storedOwner",
+        JSON.stringify({ id: "2" })
+      );
+    });
+  });
+
+  describe("store value", () => {
+    it("should reflect new value after set", async () => {
+      const { storedOwner } = await import("./owner.store");
+
+      storedOwner.set({ id: "7" });
+
+      expect(get(storedOwner)).toEqual({ id: "7" });
+    });
+
+    it("should reflect new value after update", async () => {
+      const { storedOwner } = await import("./owner.store");
+
+      storedOwner.update((current) => ({ ...current, id: "8" }));
+
+      expect(get(storedOwner)).toEqual({ id: "8" });
+    });
+
+    it("should allow clearing the id", async () => {
+      storageData["storedOwner"] = JSON.stringify({ id: "5" });
+      const { storedOwner } = await import("./owner.store");
+
+      storedOwner.set({ id: undefined });
+
+      expect(get(storedOwner)).toEqual({ id: undefined });
+    });
+  });
+});

--- a/app/client-svelte/tsconfig.json
+++ b/app/client-svelte/tsconfig.json
@@ -19,11 +19,6 @@
     "declarationMap": false,
     "outDir": "./build",
     "rootDir": "./src",
-    "baseUrl": ".",
-    "paths": {
-      "$lib/*": ["src/main/svelte/lib/*"],
-      "$app/*": ["src/main/svelte/app/*"]
-    }
   },
   "include": [
     "src/**/*.d.ts",

--- a/app/client-svelte/vitest.config.ts
+++ b/app/client-svelte/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     },
     coverage: {
       provider: "v8",
+      reporter: ["text", "html"],
       include: [
         "src/main/svelte/router/*.ts",
         "src/main/svelte/services/*.ts",

--- a/app/client-svelte/vitest.config.ts
+++ b/app/client-svelte/vitest.config.ts
@@ -1,17 +1,26 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ['src/main/svelte/**/*.{test,spec}.{js,ts}'],
-    environment: 'node',
+    include: ["src/main/svelte/**/*.{test,spec}.{js,ts}"],
+    environment: "node",
     globals: true,
-    reporters: ['default', 'junit'],
+    reporters: ["default", "junit"],
     outputFile: {
-      junit: './build/test-results/test/TEST-vitest.xml'
+      junit: "./build/test-results/test/TEST-vitest.xml",
     },
-    setupFiles: ['./vitest.setup.js'],
+    setupFiles: ["./vitest.setup.js"],
     typecheck: {
-      enabled: true
-    }
+      enabled: true,
+    },
+    coverage: {
+      provider: "v8",
+      include: [
+        "src/main/svelte/router/*.ts",
+        "src/main/svelte/services/*.ts",
+        "src/main/svelte/stores/*.ts",
+      ],
+      reportsDirectory: "./build/coverage",
+    },
   },
-})
+});

--- a/lib/backend-api/build.gradle
+++ b/lib/backend-api/build.gradle
@@ -68,6 +68,11 @@ jacocoTestReport {
     }
 }
 
+tasks.register('coverageTestReport') {
+    group = 'verification'
+    dependsOn 'jacocoTestReport'
+}
+
 jar {
     enabled = true
     manifest {

--- a/lib/backend-data/build.gradle
+++ b/lib/backend-data/build.gradle
@@ -69,6 +69,11 @@ jacocoTestReport {
     }
 }
 
+tasks.register('coverageTestReport') {
+    group = 'verification'
+    dependsOn 'jacocoTestReport'
+}
+
 jar {
     enabled = true
     manifest {

--- a/pages/index.html
+++ b/pages/index.html
@@ -60,7 +60,7 @@
     <p>
       <a href="html/server/service/visit-graphql.html" target="_blank"><code>Visit GraphQL API</code></a>
     </p>
-    <h1>Integration testing with Playwright</h1>
+    <h1>Frontend testing with Playwright</h1>
     <p>
       <a href="https://playwright.dev/" target="_blank">Playwright</a>
       enables reliable end-to-end testing for web apps.
@@ -70,6 +70,17 @@
     </p>
     <p>
       <a href="html/client-svelte/playwright/index.html" target="_blank"><code>client-svelte</code></a>
+    </p>
+    <h1>Coverage analysis with V8</h1>
+    <p>
+      <a href="https://vitest.dev/guide/coverage.html" target="_blank">Vitest</a>
+      is used to measure the coverage of the Javascript code with tests.
+    </p>
+    <p>
+      <a href="html/client-angular/coverage/index.html" target="_blank"><code>client-angular</code></a>
+    </p>
+    <p>
+      <a href="html/client-svelte/coverage/index.html" target="_blank"><code>client-svelte</code></a>
     </p>
     <h1>Component testing with JUnit5</h1>
     <p>
@@ -88,7 +99,7 @@
     <h1>Coverage analysis with JaCoCo</h1>
     <p>
       <a href="https://www.eclemma.org/jacoco/" target="_blank">JaCoCo</a>
-      is used to measure the quality of the code in Java projects in terms of test coverage.
+      is used to measure the coverage of the Java code with tests.
     </p>
     <p>
       <a href="html/backend-api/jacoco/index.html" target="_blank"><code>backend-api</code></a>

--- a/pages/index.html
+++ b/pages/index.html
@@ -9,9 +9,6 @@
     </p>
     <h2>Concepts</h2>
     <p>
-      <a href="html/server/concept/spring/entity.html" target="_blank"><code>Entity concept</code></a>
-    </p>
-    <p>
       <a href="html/server/concept/spring/endpoint.html" target="_blank"><code>Endpoint concept</code></a>
     </p>
     <p>


### PR DESCRIPTION
```
Add code coverage to app/client-angular
```

```
Add a gradle task coverageTestReport in the build.gradle of app/client-angular that moves the coverage results from build/converage to pages/html/client-angular in the project root.
```

```
Add code coverage to app/client-svelte
```

```
Add a gradle task coverageTestReport in the build.gradle of app/client-svelte that moves the coverage results from build/converage to pages/html/client-svelte in the project root.
```

```
Fix bad coverage in enum.service.ts
```

```
Create vitest unit test for owner.store.ts
```
