### PR TITLE
feat: Liquibase ist extra Job bei PostgreSQL

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,6 +12,12 @@ https://spring.io/projects/spring-boot
 
 http://hsqldb.org
 
+=== app/migrate
+
+Backend database migration tool.
+
+https://docs.liquibase.com
+
 === app/client-angular
 
 Browser-based web client of the application.
@@ -19,6 +25,8 @@ Browser-based web client of the application.
 https://angular.dev
 
 https://tailwindcss.com
+
+https://vitejs.dev
 
 === app/client-svelte
 
@@ -192,7 +200,16 @@ The Svelte client is accessed in the browser at `localhost:5050`.
 ./gradlew deployUp
 ----
 
-This command starts clients and server locally.
+This command runs the server with an embedded database and all clients locally.
+The Angular client is accessed in the browser at `localhost:5052`.
+The Svelte client is accessed in the browser at `localhost:5050`.
+
+[source, gradle]
+----
+./gradlew deployUp -PcomposeFile=compose-pg.yml
+----
+
+This command runs a postgreSQL database, runs the liquibase migration and runs server with the postgreSQL database and all clients locally.
 The Angular client is accessed in the browser at `localhost:5052`.
 The Svelte client is accessed in the browser at `localhost:5050`.
 
@@ -201,7 +218,7 @@ The Svelte client is accessed in the browser at `localhost:5050`.
 ./gradlew deployDown
 ----
 
-This command stops clients and server.
+This command stops all containers.
 
 === Testing application locally
 

--- a/app/deploy/build.gradle
+++ b/app/deploy/build.gradle
@@ -5,6 +5,7 @@ plugins {
 tasks.register('deployUp') {
     mustRunAfter ':app:client-angular:buildImage'
     mustRunAfter ':app:client-svelte:buildImage'
+    mustRunAfter ':app:migrate:buildImage'
     mustRunAfter ':app:server:buildImage'
     doLast {
         def composeFileName = System.getenv('COMPOSE_FILE') ?: (project.findProperty('composeFile') ?: 'compose.yml')

--- a/app/deploy/build.gradle
+++ b/app/deploy/build.gradle
@@ -7,11 +7,14 @@ tasks.register('deployUp') {
     mustRunAfter ':app:client-svelte:buildImage'
     mustRunAfter ':app:server:buildImage'
     doLast {
-        println '\nDeploying with latest'
+        def composeFileName = System.getenv('COMPOSE_FILE') ?: (project.findProperty('composeFile') ?: 'compose.yml')
+        if (!file(composeFileName).exists()) {
+            throw new GradleException("'${composeFileName}' not found. Use COMPOSE_FILE or -PcomposeFile.")
+        }
         providers.exec {
             workingDir(projectDir)
             executable 'docker'
-            args 'compose', '-p', 'petclinic', '-f', 'compose.yml', 'up', '--detach', '--no-build'
+            args 'compose', '-p', rootProject.name, '-f', composeFileName, 'up', '--detach', '--no-build'
         }.result.get()
     }
 }
@@ -21,7 +24,7 @@ tasks.register('deployDown') {
         providers.exec {
             workingDir(projectDir)
             executable 'docker'
-            args 'compose', '-p', 'petclinic', '-f', 'compose.yml', 'down'
+            args 'compose', '-p', rootProject.name, 'down'
         }.result.get()
     }
 }

--- a/app/deploy/compose-pg.yml
+++ b/app/deploy/compose-pg.yml
@@ -1,0 +1,58 @@
+services:
+  client-angular:
+    hostname: client-angular
+    image: ${COMPOSE_PROJECT_NAME}/client-angular
+    ports:
+      - 5052:5052
+  client-svelte:
+    hostname: client-svelte
+    image: ${COMPOSE_PROJECT_NAME}/client-svelte
+    ports:
+      - 5050:5050
+  server:
+    hostname: server
+    image: ${COMPOSE_PROJECT_NAME}/server
+    ports:
+      - 5005:5005
+      - 8080:8080
+    environment:
+      - _JAVA_OPTIONS=-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
+      - SERVER_PORT=8080
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres
+      - SPRING_DATASOURCE_USERNAME=sa
+      - SPRING_DATASOURCE_PASSWORD=P@ssw0rd
+      - SPRING_PROFILES_ACTIVE=dev
+    depends_on:
+      postgres17:
+        condition: service_healthy
+  migrate:
+    restart: "no"
+    hostname: migrate
+    image: ${COMPOSE_PROJECT_NAME}/migrate
+    environment:
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres
+      - SPRING_DATASOURCE_USERNAME=sa
+      - SPRING_DATASOURCE_PASSWORD=P@ssw0rd
+      - SPRING_LIQUIBASE_CHANGE_LOG=liquibase/changelog.xml
+    depends_on:
+      postgres17:
+        condition: service_healthy
+  postgres17:
+    hostname: postgres17
+    image: postgres:17@sha256:0b6428e8c09651398137d2b3308a6ad87e73ac15fc38729891c16d942e947d3d
+    command: ["postgres", "-c", "wal_level=logical"]
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres17:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=postgres
+      - POSTGRES_USER=sa
+      - POSTGRES_PASSWORD=P@ssw0rd
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U sa -d postgres -h localhost"]
+      interval: 2s
+      timeout: 1s
+      retries: 30
+volumes:
+  postgres17:

--- a/app/migrate/build.gradle
+++ b/app/migrate/build.gradle
@@ -1,0 +1,122 @@
+plugins {
+    id 'java'
+    id 'io.spring.dependency-management'
+    id 'org.springframework.boot'
+    id 'com.google.cloud.tools.jib'
+    id 'com.diffplug.spotless'
+}
+
+spotless {
+    encoding 'UTF-8'
+    java {
+        target fileTree(projectDir) {
+            include 'src/main/java/**/*.java'
+            exclude 'build/**'
+        }
+        leadingTabsToSpaces(4)
+        removeUnusedImports()
+    }
+}
+
+dependencies {
+    implementation project(':lib:backend-data')
+    // https://projectlombok.org
+    implementation('org.projectlombok:lombok')
+    annotationProcessor('org.projectlombok:lombok')
+    // http://hsqldb.org/
+    runtimeOnly('org.hsqldb:hsqldb')
+    runtimeOnly('org.postgresql:postgresql')
+}
+dependencies {
+    // https://spring.io/projects/spring-boot
+    testImplementation('org.springframework.boot:spring-boot-starter-test')
+    // https://junit.org/junit5
+    testImplementation('org.junit.jupiter:junit-jupiter')
+    testRuntimeOnly('org.junit.platform:junit-platform-launcher')
+    // https://site.mockito.org/
+    testImplementation('org.mockito:mockito-junit-jupiter')
+    // https://playwright.dev/java/
+    testImplementation(extraLibs.playwright)
+}
+
+// tag::processResources[]
+processResources {
+    from("${rootDir}")
+    include 'VERSION'
+}
+// end::processResources[]
+
+test {
+    filter {
+        failOnNoMatchingTests = false
+    }
+    reports {
+        html.required = true
+    }
+}
+
+tasks.register('testReport', Copy) {
+    group = 'verification'
+    mustRunAfter 'test'
+    from layout.buildDirectory.dir('reports/tests/test')
+    into rootProject.layout.projectDirectory.dir('pages/html/' + project.name + '/test')
+}
+
+jar {
+    enabled = false
+}
+
+bootJar {
+    enabled = false
+}
+
+ext.SERVER_IMAGE = java.util.Optional.ofNullable(System.getenv("SERVER_IMAGE"))
+            .orElse(rootProject.name + "/" + project.name)
+ext.SERVER_TAG = java.util.Optional.ofNullable(System.getenv("SERVER_TAG"))
+            .orElse('latest')
+
+// tag::bootBuildImage[]
+bootBuildImage {
+    enabled = false
+}
+// end::bootBuildImage[]
+
+// tag::jibDockerBuild[]
+jib {
+    from {
+        image = "eclipse-temurin:21-jdk-alpine@sha256:cafcfad1d9d3b6e7dd983fa367f085ca1c846ce792da59bcb420ac4424296d56"
+    }
+    to {
+        image = SERVER_IMAGE + ":" + SERVER_TAG
+        tags = [VERSION]
+    }
+    container {
+        labels = [
+            "org.springframework.boot.version": org.springframework.boot.gradle.plugin.SpringBootPlugin.package.implementationVersion,
+            "org.opencontainers.image.title": project.name,
+            "org.opencontainers.image.version": VERSION
+        ]
+    }
+}
+// end::jibDockerBuild[]
+
+tasks.register('buildImage') {
+    group = 'build'
+    enabled = true
+    mustRunAfter 'build'
+    dependsOn 'jibDockerBuild'
+}
+
+tasks.register('versionCheck', VersionCheckTask.class)  {
+    group = 'verification'
+}
+
+tasks.register('lint') {
+    group = 'verification'
+    dependsOn 'spotlessCheck'
+}
+
+tasks.register('format') {
+    group = 'build'
+    dependsOn 'spotlessApply'
+}

--- a/app/migrate/src/main/java/esy/migrate/MigrateRunner.java
+++ b/app/migrate/src/main/java/esy/migrate/MigrateRunner.java
@@ -1,0 +1,42 @@
+package esy.migrate;
+
+import java.sql.DriverManager;
+import liquibase.Contexts;
+import liquibase.LabelExpression;
+import liquibase.Liquibase;
+import liquibase.database.DatabaseFactory;
+import liquibase.database.jvm.JdbcConnection;
+import liquibase.resource.ClassLoaderResourceAccessor;
+
+public final class MigrateRunner {
+
+    private MigrateRunner() {
+    }
+
+    public static void main(final String[] args) throws Exception {
+        try {
+            final var jdbcUrl = requireEnv("SPRING_DATASOURCE_URL");
+            final var username = requireEnv("SPRING_DATASOURCE_USERNAME");
+            final var password = requireEnv("SPRING_DATASOURCE_PASSWORD");
+            final var changeLog = requireEnv("SPRING_LIQUIBASE_CHANGE_LOG");
+            final var accessor = new ClassLoaderResourceAccessor(MigrateRunner.class.getClassLoader());
+            try (final var connection = DriverManager.getConnection(jdbcUrl, username, password)) {
+                final var database = DatabaseFactory.getInstance()
+                        .findCorrectDatabaseImplementation(new JdbcConnection(connection));
+                try (var liquibase = new Liquibase(changeLog, accessor, database)) {
+                    liquibase.update(new Contexts(), new LabelExpression());
+                }
+            }
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+    private static String requireEnv(final String name) {
+        final var value = System.getenv(name);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException("Missing environment variable " + name + '.');
+        }
+        return value;
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
     id 'idea'
     id 'com.palantir.git-version'
     id 'org.asciidoctor.jvm.convert'
+    id 'com.diffplug.spotless' apply false
 }
 
 eclipse {

--- a/doc/concept/spring/database.adoc
+++ b/doc/concept/spring/database.adoc
@@ -64,6 +64,10 @@ The `preConditions` element provides additional safety by checking the database 
 The `onFail="MARK_RAN"` attribute tells Liquibase to mark the changeSet as already executed if the preconditions fail, preventing errors and ensuring idempotent database migrations.
 This ensures that Liquibase only creates a table if this table does not exist.
 
-When running tests with the H2 database the same database schema may be recreated multiple times during test execution.
+==== Migration
 
-When running the application with the PostgreSQL database, only new incremental schema changes are applied.
+When running the application or tests with the HyperSQL database in-memory, a full schema migration is executed automatically during application startup.
+This ensures that local development and automated tests always initialize or recreate the schema from the changelog without a separate migration step.
+
+When running the application with the PostgreSQL database, an incremetal schema migration is executed as a dedicated migration step before the backend server starts.
+This keeps startup of the application service independent from schema change execution and avoids coupling operational deployment with migration concerns.

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ dependencyResolutionManagement {
 include 'lib:backend-api'
 include 'lib:backend-data'
 include 'app:server'
+include 'app:migrate'
 include 'app:client-svelte'
 include 'app:client-angular'
 include 'app:deploy'


### PR DESCRIPTION
## Goal

Separate Liquibase migration from normal backend server startup in PostgreSQL environments, while preserving automatic Liquibase execution for HSQLDB-based tests.

## Implementation Constraints

1. Use Java 21.
2. Use Gradle Groovy DSL.
3. Do not use the official Liquibase Docker image.
4. Build a dedicated migration container with a multistage Dockerfile.
5. Keep Liquibase dependency version aligned with Spring Boot BOM and existing dependency graph.
6. Reuse existing changelog and database properties from backend-data; do not duplicate changelog content.
7. Prefer Spring Boot auto-configuration for Liquibase instead of manual Liquibase API wiring.
8. Server does not execute Liquibase migration on startup in PostgreSQL deployment.
9. Dedicated migrate container executes Liquibase successfully.
10. Changelog and database properties are reused from backend-data.
11. No duplicated changelog files are introduced.
12. deployUp and deployDown use rootProject.name for compose project naming.
13. Database concept documentation includes the new Liquibase Migration subsection.

## Implementation Tasks

1. Add module app/migrate.
2. Include app/migrate in settings.gradle.
3. Create app/migrate/build.gradle:
   - Configure bootJar.
   - Set main class to esy.migrate.MigrateRunner.
   - Add dependency on lib/backend-data.
   - Configure container image build with Jib, consistent with existing modules.
4. Create app/migrate/src/main/java/esy/migrate/MigrateRunner.java:
   - Spring Boot app in non-web mode.
   - Start, run Liquibase via auto-config, then exit process.
   - Load classpath database.properties so spring.liquibase.change-log resolves correctly.
   - Exclude GraphQL auto-config if needed to avoid non-web startup failures.
5. Create app/migrate/src/main/resources/application.properties with minimal migration-specific settings.
6. Create app/migrate/Dockerfile as multistage:
   - Builder: Java 21 JDK, build bootJar via Gradle.
   - Runtime: Java 21 JRE Alpine, run migration jar.
   - No standalone Liquibase CLI installation.
7. Update deployment compose file used by app/deploy:
   - Ensure PostgreSQL service exists with health check.
   - Add migrate service that waits for PostgreSQL, runs once, and exits.
   - Provide datasource and Liquibase config via SPRING_* environment variables.
   - Update server service to depend on migrate completion and set SPRING_LIQUIBASE_ENABLED=false.
8. Update app/deploy/build.gradle:
   - Wire deployUp and deployDown for migrate image/service as needed.
   - Replace hardcoded project name petclinic in compose args with rootProject.name.
9. Update doc/concept/spring/database.adoc:
   - Under Liquibase, add a level-3 Migration subsection describing:
     - PostgreSQL uses a dedicated pre-start migration step.
     - HSQLDB and tests keep automatic Liquibase execution at startup.
     - Why this separation exists.
   - Use HSQLDB terminology consistently.

## Validation

Run, verify and report:
1. Gradle build for app/migrate.
2. Container image build for migrate container image.
4. Compose file works with PostgreSQL database with separate Liquibase migration
4. Compose file works with HyperSQL database with automatic Liquibase migration
5. Existing tests with HyperSQL database still run with automatic Liquibase migration
