### PR TITLE
copilot: Agent implementiert eine @Column vom Typ Duration

### DIFF
--- a/PROMPT.adoc
+++ b/PROMPT.adoc
@@ -34,7 +34,7 @@ Create an enum InvoiceStatus with values D for drafted, I for issued, C for comp
 
 .Prompt
 ----
-Create an entity Invoice with required property at of type LocalDate, with required property due of type LocalDate, with required property status of type InvoiceStatus, with required non-blank property text of type String, in package clinic.
+Create an entity Invoice with required property issued of type LocalDate, with required property period of type Duration, with required property status of type InvoiceStatus, with required non-blank property text of type String, in package clinic.
 ----
 
 == Domain entity property adder

--- a/app/client-angular/src/main/angular/pages/clinic/visit-diagnose/visit-diagnose.html
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-diagnose/visit-diagnose.html
@@ -9,6 +9,48 @@
         placeholder="Enter a diagnose"
       ></textarea>
     </fieldset>
+    <div class="flex flex-col sm:flex-row gap-2">
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Time</legend>
+        <input
+          formControlName="time"
+          aria-label="Time"
+          type="time"
+          class="input w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Duration</legend>
+        <div class="flex gap-1">
+          <input
+            formControlName="durationHours"
+            aria-label="Hours"
+            type="number"
+            min="0"
+            class="input w-full"
+            placeholder="h"
+          />
+          <input
+            formControlName="durationMinutes"
+            aria-label="Minutes"
+            type="number"
+            min="0"
+            max="59"
+            class="input w-full"
+            placeholder="m"
+          />
+          <input
+            formControlName="durationSeconds"
+            aria-label="Seconds"
+            type="number"
+            min="0"
+            max="59"
+            class="input w-full"
+            placeholder="s"
+          />
+        </div>
+      </fieldset>
+    </div>
     <fieldset class="fieldset w-full">
       <legend class="fieldset-legend">Vet</legend>
       <select formControlName="vet" aria-label="Vet" class="select w-full">

--- a/app/client-angular/src/main/angular/pages/clinic/visit-diagnose/visit-diagnose.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-diagnose/visit-diagnose.ts
@@ -34,12 +34,35 @@ export class VisitDiagnoseComponent implements OnInit {
   visit = input.required<Visit>();
   form = new FormGroup({
     text: new FormControl("", Validators.required),
+    time: new FormControl(""),
+    durationHours: new FormControl<number>(0),
+    durationMinutes: new FormControl<number>(0),
+    durationSeconds: new FormControl<number>(0),
     vet: new FormControl("", Validators.required),
   });
 
+  private parseDuration(iso: string): { h: number; m: number; s: number } {
+    const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(iso ?? "");
+    return {
+      h: match ? Number(match[1] ?? 0) : 0,
+      m: match ? Number(match[2] ?? 0) : 0,
+      s: match ? Number(match[3] ?? 0) : 0,
+    };
+  }
+
+  private composeDuration(h: number, m: number, s: number): string | undefined {
+    if (!h && !m && !s) return undefined;
+    return "PT" + (h ? h + "H" : "") + (m ? m + "M" : "") + (s ? s + "S" : "");
+  }
+
   ngOnInit() {
+    const d = this.parseDuration(this.visit().duration ?? "");
     this.form.patchValue({
       text: this.visit().text,
+      time: this.visit().time ?? "",
+      durationHours: d.h,
+      durationMinutes: d.m,
+      durationSeconds: d.s,
       vet: this.visit().vetItem?.value || "",
     });
   }
@@ -50,8 +73,13 @@ export class VisitDiagnoseComponent implements OnInit {
 
   cancelEmitter = output<Visit>({ alias: "cancel" });
   onCancelClicked() {
+    const d = this.parseDuration(this.visit().duration ?? "");
     this.form.patchValue({
       text: this.visit().text,
+      time: this.visit().time ?? "",
+      durationHours: d.h,
+      durationMinutes: d.m,
+      durationSeconds: d.s,
       vet: this.visit().vetItem?.value || "",
     });
     this.form.markAsPristine();
@@ -65,6 +93,12 @@ export class VisitDiagnoseComponent implements OnInit {
     const newVisit = {
       ...this.visit(),
       text: this.form.value.text!,
+      time: this.form.value.time || undefined,
+      duration: this.composeDuration(
+        this.form.value.durationHours ?? 0,
+        this.form.value.durationMinutes ?? 0,
+        this.form.value.durationSeconds ?? 0
+      ),
       vetItem: undefined, // vetItem is invalid
       vet: "/api/vet/" + this.form.value.vet!,
     };

--- a/app/client-angular/src/main/angular/pages/clinic/visit-treatment/visit-treatment.html
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-treatment/visit-treatment.html
@@ -1,6 +1,6 @@
 <form [formGroup]="form" (ngSubmit)="onSubmitClicked()">
-  <div class="flex flex-col gap-2 pt-4">
-    <fieldset class="fieldset w-48">
+  <div class="flex flex-col sm:flex-row gap-2 pt-4">
+    <fieldset class="fieldset w-full">
       <legend class="fieldset-legend">Treatment</legend>
       <input
         formControlName="date"
@@ -8,6 +8,15 @@
         type="date"
         class="input w-full"
         placeholder="Choose a date"
+      />
+    </fieldset>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Time</legend>
+      <input
+        formControlName="time"
+        aria-label="Time"
+        type="time"
+        class="input w-full"
       />
     </fieldset>
   </div>

--- a/app/client-angular/src/main/angular/pages/clinic/visit-treatment/visit-treatment.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-treatment/visit-treatment.ts
@@ -31,11 +31,13 @@ export class VisitTreatmentComponent implements OnInit {
   visit = input.required<Visit>();
   form = new FormGroup({
     date: new FormControl("", Validators.required),
+    time: new FormControl(""),
   });
 
   ngOnInit() {
     this.form.patchValue({
       date: this.visit().date,
+      time: this.visit().time ?? "",
     });
   }
 
@@ -47,6 +49,7 @@ export class VisitTreatmentComponent implements OnInit {
   onCancelClicked() {
     this.form.patchValue({
       date: this.visit().date,
+      time: this.visit().time ?? "",
     });
     this.form.markAsPristine();
     this.cancelEmitter.emit(this.visit());
@@ -59,6 +62,7 @@ export class VisitTreatmentComponent implements OnInit {
     const newVisit = {
       ...this.visit(),
       date: this.form.value.date!,
+      time: this.form.value.time || undefined,
     };
     if (this.visit().id) {
       const subscription = this.visitService

--- a/app/client-angular/src/main/angular/pages/clinic/visit-viewer/visit-viewer.html
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-viewer/visit-viewer.html
@@ -7,6 +7,20 @@
     </div>
   } @else {
     @if (visit()) {
+      <div class="flex flex-col sm:flex-row gap-2 pt-4">
+        <fieldset class="fieldset w-full">
+          <legend class="fieldset-legend">Date</legend>
+          <p class="p-2">{{ visit()!.date }}</p>
+        </fieldset>
+        <fieldset class="fieldset w-full">
+          <legend class="fieldset-legend">Time</legend>
+          <p class="p-2">{{ visit()!.time ?? "-" }}</p>
+        </fieldset>
+        <fieldset class="fieldset w-full">
+          <legend class="fieldset-legend">Duration</legend>
+          <p class="p-2">{{ formatDuration(visit()!.duration) }}</p>
+        </fieldset>
+      </div>
       <app-visit-treatment [visible]="true" [visit]="visit()!" />
       <app-visit-diagnose
         [visible]="true"

--- a/app/client-angular/src/main/angular/pages/clinic/visit-viewer/visit-viewer.ts
+++ b/app/client-angular/src/main/angular/pages/clinic/visit-viewer/visit-viewer.ts
@@ -55,4 +55,18 @@ export class VisitViewerComponent implements OnInit {
   get title() {
     return "of " + this.visit()?.petItem?.text + " on " + this.visit()?.date;
   }
+
+  formatDuration(iso: string | undefined): string {
+    if (!iso) return "-";
+    const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(iso);
+    if (!match) return iso;
+    const parts: string[] = [];
+    if (match[1])
+      parts.push(match[1] + (Number(match[1]) === 1 ? " hour" : " hours"));
+    if (match[2])
+      parts.push(match[2] + (Number(match[2]) === 1 ? " minute" : " minutes"));
+    if (match[3])
+      parts.push(match[3] + (Number(match[3]) === 1 ? " second" : " seconds"));
+    return parts.length ? parts.join(" ") : "-";
+  }
 }

--- a/app/client-angular/src/main/angular/types/visit.type.ts
+++ b/app/client-angular/src/main/angular/types/visit.type.ts
@@ -6,6 +6,8 @@ export interface Visit {
   id?: string;
   version: number;
   date: string;
+  time?: string;
+  duration?: string;
   text: string;
   ownerItem?: OwnerItem;
   petItem?: PetItem;

--- a/app/client-angular/src/test/playwright/App.e2e.js
+++ b/app/client-angular/src/test/playwright/App.e2e.js
@@ -90,7 +90,7 @@ test.describe("Visit", () => {
       "M",
       "2022-03-09"
     );
-    await petPage.createVisit(ownerName, petName, "2025-04-22");
+    await petPage.createVisit(ownerName, petName, "2025-04-22", "09:30");
     const visitPage = new VisitListerPage(page);
     await visitPage.goto();
     await visitPage.updateDiagnose(ownerName, petName);

--- a/app/client-angular/src/test/playwright/pages/PetListerPage.js
+++ b/app/client-angular/src/test/playwright/pages/PetListerPage.js
@@ -82,7 +82,7 @@ export class PetListerPage {
     return petName;
   }
 
-  async createVisit(ownerName, petName, date) {
+  async createVisit(ownerName, petName, date, time) {
     await this.filterOwner(ownerName);
     const row = this.page
       .getByRole("table")
@@ -99,6 +99,12 @@ export class PetListerPage {
     await dateInput.fill(date);
     await dateInput.press("Tab");
     await expect(dateInput).toHaveValue(date);
+    // Time
+    const timeInput = this.page.locator('[aria-label="Time"]');
+    await expect(timeInput).not.toHaveValue(time);
+    await timeInput.fill(time);
+    await timeInput.press("Tab");
+    await expect(timeInput).toHaveValue(time);
     // Ok
     const okButton = this.page.getByRole("button", { name: "Ok", exact: true });
     await expect(okButton).toBeEnabled();

--- a/app/client-angular/src/test/playwright/pages/VisitListerPage.js
+++ b/app/client-angular/src/test/playwright/pages/VisitListerPage.js
@@ -33,6 +33,24 @@ export class VisitListerPage {
     await textInput.fill(text);
     await textInput.press("Tab");
     expect(textInput).toHaveValue(text);
+    // Time
+    const timeInput = this.page.locator('[aria-label="Time"]');
+    await expect(timeInput).not.toHaveValue("");
+    await timeInput.fill("10:15");
+    await timeInput.press("Tab");
+    await expect(timeInput).toHaveValue("10:15");
+    // Duration hours
+    const hoursInput = this.page.locator('[aria-label="Hours"]');
+    await expect(hoursInput).toHaveValue("0");
+    await hoursInput.fill("1");
+    await hoursInput.press("Tab");
+    await expect(hoursInput).toHaveValue("1");
+    // Duration minutes
+    const minutesInput = this.page.locator('[aria-label="Minutes"]');
+    await expect(minutesInput).toHaveValue("0");
+    await minutesInput.fill("30");
+    await minutesInput.press("Tab");
+    await expect(minutesInput).toHaveValue("30");
     // Vet
     const vetSelect = this.page.locator('[aria-label="Vet"]');
     await expect(vetSelect).toHaveValue("");

--- a/app/client-svelte/src/main/svelte/pages/clinic/VisitDiagnose.svelte
+++ b/app/client-svelte/src/main/svelte/pages/clinic/VisitDiagnose.svelte
@@ -38,12 +38,47 @@
     if (autoscroll) bottomDiv.scrollIntoView(false);
   });
 
+  function parseDuration(iso: string): { h: number; m: number; s: number } {
+    const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(iso ?? "");
+    return {
+      h: match ? Number(match[1] ?? 0) : 0,
+      m: match ? Number(match[2] ?? 0) : 0,
+      s: match ? Number(match[3] ?? 0) : 0,
+    };
+  }
+
+  function composeDuration(
+    h: number,
+    m: number,
+    s: number
+  ): string | undefined {
+    if (!h && !m && !s) return undefined;
+    return "PT" + (h ? h + "H" : "") + (m ? m + "M" : "") + (s ? s + "S" : "");
+  }
+
   let newVisitText = $derived(visit.text);
+  let newVisitTime = $state("");
+  let newVisitDurationH = $state(0);
+  let newVisitDurationM = $state(0);
+  let newVisitDurationS = $state(0);
+  $effect(() => {
+    newVisitTime = visit.time ?? "";
+    const d = parseDuration(visit.duration ?? "");
+    newVisitDurationH = d.h;
+    newVisitDurationM = d.m;
+    newVisitDurationS = d.s;
+  });
   let newVisitPetId = $derived(visit.petItem?.value);
   let newVisitVetId = $derived(visit.vetItem?.value);
   const newVisit = $derived({
     ...visit,
     text: newVisitText,
+    time: newVisitTime || undefined,
+    duration: composeDuration(
+      newVisitDurationH,
+      newVisitDurationM,
+      newVisitDurationS
+    ),
     petItem: undefined, // petItem is invalid
     pet: newVisitPetId ? "/api/pet/" + newVisitPetId : undefined,
     vetItem: undefined, // vetItem is invalid
@@ -99,6 +134,48 @@
         placeholder="Enter a diagnose"
       ></textarea>
     </fieldset>
+    <div class="flex flex-col sm:flex-row gap-2">
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Time</legend>
+        <input
+          bind:value={newVisitTime}
+          aria-label="Time"
+          type="time"
+          class="input w-full"
+        />
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Duration</legend>
+        <div class="flex gap-1">
+          <input
+            bind:value={newVisitDurationH}
+            aria-label="Hours"
+            type="number"
+            min="0"
+            class="input w-full"
+            placeholder="h"
+          />
+          <input
+            bind:value={newVisitDurationM}
+            aria-label="Minutes"
+            type="number"
+            min="0"
+            max="59"
+            class="input w-full"
+            placeholder="m"
+          />
+          <input
+            bind:value={newVisitDurationS}
+            aria-label="Seconds"
+            type="number"
+            min="0"
+            max="59"
+            class="input w-full"
+            placeholder="s"
+          />
+        </div>
+      </fieldset>
+    </div>
     <fieldset class="fieldset w-full">
       <legend class="fieldset-legend">Vet</legend>
       <select bind:value={newVisitVetId} aria-label="Vet" class="select w-full">

--- a/app/client-svelte/src/main/svelte/pages/clinic/VisitTreatment.svelte
+++ b/app/client-svelte/src/main/svelte/pages/clinic/VisitTreatment.svelte
@@ -36,12 +36,18 @@
   });
 
   let newVisitDate = $state("");
+  let newVisitTime = $state("");
+  $effect(() => {
+    newVisitDate = visit.date ?? "";
+    newVisitTime = visit.time ?? "";
+  });
   let newVisitPetId = $derived(visit.petItem?.value);
   const newVisit: Visit = $derived({
     ...visit,
     petItem: undefined, // petItem is invalid
     pet: newVisitPetId ? "/api/pet/" + newVisitPetId : undefined,
     date: newVisitDate,
+    time: newVisitTime || undefined,
   });
 
   function onSubmitClicked(_event: Event) {
@@ -82,8 +88,8 @@
 </script>
 
 <form onsubmit={onSubmitClicked}>
-  <div class="flex flex-col gap-2 pt-4">
-    <fieldset class="fieldset w-48">
+  <div class="flex flex-col sm:flex-row gap-2 pt-4">
+    <fieldset class="fieldset w-full">
       <legend class="fieldset-legend">Treatment</legend>
       <input
         bind:this={focusOn}
@@ -92,6 +98,15 @@
         type="date"
         class="input w-full"
         placeholder="Choose a date"
+      />
+    </fieldset>
+    <fieldset class="fieldset w-full">
+      <legend class="fieldset-legend">Time</legend>
+      <input
+        bind:value={newVisitTime}
+        aria-label="Time"
+        type="time"
+        class="input w-full"
       />
     </fieldset>
   </div>

--- a/app/client-svelte/src/main/svelte/pages/clinic/VisitViewer.svelte
+++ b/app/client-svelte/src/main/svelte/pages/clinic/VisitViewer.svelte
@@ -33,6 +33,20 @@
       loading = false;
     }
   });
+
+  function formatDuration(iso: string | undefined): string {
+    if (!iso) return "-";
+    const match = /^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/.exec(iso);
+    if (!match) return iso;
+    const parts: string[] = [];
+    if (match[1])
+      parts.push(match[1] + (Number(match[1]) === 1 ? " hour" : " hours"));
+    if (match[2])
+      parts.push(match[2] + (Number(match[2]) === 1 ? " minute" : " minutes"));
+    if (match[3])
+      parts.push(match[3] + (Number(match[3]) === 1 ? " second" : " seconds"));
+    return parts.length ? parts.join(" ") : "-";
+  }
 </script>
 
 <h1>Visit of {visit?.petItem?.text + " on " + visit.date}</h1>
@@ -40,6 +54,22 @@
   {#if loading}
     <div class="h-screen flex justify-center items-start">
       <span class="loading loading-spinner loading-xl"></span>
+    </div>
+  {/if}
+  {#if visit.id}
+    <div class="flex flex-col sm:flex-row gap-2 pt-4">
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Date</legend>
+        <p class="p-2">{visit.date}</p>
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Time</legend>
+        <p class="p-2">{visit.time ?? "-"}</p>
+      </fieldset>
+      <fieldset class="fieldset w-full">
+        <legend class="fieldset-legend">Duration</legend>
+        <p class="p-2">{formatDuration(visit.duration)}</p>
+      </fieldset>
     </div>
   {/if}
 </div>

--- a/app/client-svelte/src/main/svelte/types/visit.type.ts
+++ b/app/client-svelte/src/main/svelte/types/visit.type.ts
@@ -6,6 +6,8 @@ export interface Visit {
   id?: string;
   version: number;
   date: string;
+  time?: string;
+  duration?: string;
   text?: string;
   ownerItem?: OwnerItem;
   petItem?: PetItem;

--- a/app/client-svelte/src/test/playwright/App.e2e.js
+++ b/app/client-svelte/src/test/playwright/App.e2e.js
@@ -90,7 +90,7 @@ test.describe("Visit", () => {
       "M",
       "2022-03-09"
     );
-    await petPage.createVisit(ownerName, petName, "2025-04-22");
+    await petPage.createVisit(ownerName, petName, "2025-04-22", "09:30");
     const visitPage = new VisitListerPage(page);
     await visitPage.goto();
     await visitPage.updateDiagnose(ownerName, petName);

--- a/app/client-svelte/src/test/playwright/pages/PetListerPage.js
+++ b/app/client-svelte/src/test/playwright/pages/PetListerPage.js
@@ -82,7 +82,7 @@ export class PetListerPage {
     return petName;
   }
 
-  async createVisit(ownerName, petName, date) {
+  async createVisit(ownerName, petName, date, time) {
     await this.filterOwner(ownerName);
     const row = this.page
       .getByRole("table")
@@ -99,6 +99,12 @@ export class PetListerPage {
     await dateInput.fill(date);
     await dateInput.press("Tab");
     await expect(dateInput).toHaveValue(date);
+    // Time
+    const timeInput = this.page.locator('[aria-label="Time"]');
+    await expect(timeInput).not.toHaveValue(time);
+    await timeInput.fill(time);
+    await timeInput.press("Tab");
+    await expect(timeInput).toHaveValue(time);
     // Ok
     const okButton = this.page.getByRole("button", { name: "Ok", exact: true });
     await expect(okButton).toBeEnabled();

--- a/app/client-svelte/src/test/playwright/pages/VisitListerPage.js
+++ b/app/client-svelte/src/test/playwright/pages/VisitListerPage.js
@@ -33,6 +33,24 @@ export class VisitListerPage {
     await textInput.fill(text);
     await textInput.press("Tab");
     expect(textInput).toHaveValue(text);
+    // Time
+    const timeInput = this.page.locator('[aria-label="Time"]');
+    await expect(timeInput).not.toHaveValue("");
+    await timeInput.fill("10:15");
+    await timeInput.press("Tab");
+    await expect(timeInput).toHaveValue("10:15");
+    // Duration hours
+    const hoursInput = this.page.locator('[aria-label="Hours"]');
+    await expect(hoursInput).toHaveValue("0");
+    await hoursInput.fill("1");
+    await hoursInput.press("Tab");
+    await expect(hoursInput).toHaveValue("1");
+    // Duration minutes
+    const minutesInput = this.page.locator('[aria-label="Minutes"]');
+    await expect(minutesInput).toHaveValue("0");
+    await minutesInput.fill("30");
+    await minutesInput.press("Tab");
+    await expect(minutesInput).toHaveValue("30");
     // Vet
     const vetSelect = this.page.locator('[aria-label="Vet"]');
     await expect(vetSelect).toHaveValue("");

--- a/doc/concept/spring/_json-jpa-entity-collection-string.adoc
+++ b/doc/concept/spring/_json-jpa-entity-collection-string.adoc
@@ -109,7 +109,7 @@ The `verify` operation may include custom validation logic.
 
 The collection is by default part of the JSON structure.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -119,7 +119,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` test verifies the happy path, e.g.
+The `json{Name}` test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -151,7 +151,7 @@ public void jsonSkill() {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -174,9 +174,9 @@ void jsonSkillConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -206,9 +206,9 @@ void saveVet(final String name) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -233,30 +233,26 @@ void queryAllVet() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new collection in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new collection in the payload for the request.
+Assert the status.
+Assert a collection in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new collection in the payload for the request.
+Assert the status.
+Assert a collection in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new collection in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the ordering of the collection elements and the size in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new collection in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new collection in the payload for the request.
-Assert the status.
-Assert the ordering of the collection elements and the size in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new collection in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the ordering of the collection elements and the size in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the ordering of the collection elements and the size in the response.

--- a/doc/concept/spring/_json-jpa-entity-column-boolean.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-boolean.adoc
@@ -85,7 +85,7 @@ The `verify` operation may include custom validation logic.
 
 The property is by default part of the JSON structure.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -95,7 +95,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` parameterized test verifies the happy path, e.g.
+The `json{Name}` parameterized test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -117,7 +117,7 @@ void jsonBillable(final boolean billable) {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -141,9 +141,9 @@ void jsonBillableConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -176,9 +176,9 @@ void saveVisit(final String text) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -203,30 +203,26 @@ void queryAllVisit() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.

--- a/doc/concept/spring/_json-jpa-entity-column-date.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-date.adoc
@@ -102,7 +102,7 @@ The property is by default part of the JSON structure.
 
 == Tests
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 The date value is provided as a string literal in `yyyy-MM-dd` format matching `DATE_PATTERN`.
@@ -113,7 +113,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` parameterized test verifies the happy path, e.g.
+The `json{Name}` parameterized test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -135,7 +135,7 @@ void jsonDate(final LocalDate date) {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -160,9 +160,9 @@ void jsonDateConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -195,9 +195,9 @@ void saveVisit(final String text) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -222,30 +222,26 @@ void queryAllVisit() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.

--- a/doc/concept/spring/_json-jpa-entity-column-duration.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-duration.adoc
@@ -1,13 +1,13 @@
-= Column for type `Long`
+= Column for type `Duration`
 
 == Domain story
 
-This implementation guide applies whenever an entity owns a non-negative `Long` property that must be persisted, exposed via the REST and GraphQL APIs.
+This implementation guide applies whenever an entity owns a `Duration` property that must be persisted as its total seconds, exposed via the REST and GraphQL APIs as an ISO-8601 duration string, and must not be null.
 
 .Example
 ....
-A pet can have a registration code to uniquely identify the animal for tracking, ensuring traceability, and maintaining animal health in external systems.
-The code is stored as a non-negative integer column on the `pet` table and is managed as part of the `Pet` entity.
+A visit has a duration indicating how long the appointment lasts.
+The duration is stored as a `BIGINT` column (total seconds) on the `visit` table and is managed as part of the `Visit` entity.
 ....
 
 == Default implementation
@@ -15,22 +15,26 @@ The code is stored as a non-negative integer column on the `pet` table and is ma
 .Entity
 [source,java,options="nowrap"]
 ----
-@PositiveOrZero <1>
-@Column(name = "code") <2>
+@NotNull <1>
+@Column(name = "duration") <2>
 @Getter <3>
 @JsonProperty <4>
-private Long code; <5>
+@JsonFormat(shape = JsonFormat.Shape.STRING) <5>
+@Convert(converter = DurationConverter.class) <6>
+private Duration duration; <7>
 ----
 
-<1> The field is marked with `@PositiveOrZero` validation constraint.
-This ensures the value is not negative (0 or greater).
+<1> The field is marked with `@NotNull` validation constraint.
+This ensures the value is not null.
 <2> The field is marked with `@Column`.
 The column name in the database is explicitly specified.
 <3> The field is marked with `@Getter`.
 This allows the current value to be queried via a getter method.
 <4> The field is marked with `@JsonProperty`.
 The value is included in the JSON structure of the REST API.
-<5> The field has the data type `Long`.
+<5> The field is marked with `@JsonFormat` to serialize the duration as an ISO-8601 string (e.g. `"PT1H30M"`).
+<6> The field is marked with `@Convert` to store the duration as total seconds in the database.
+<7> The field has type `Duration`.
 This is a mutable field due to requirements from the JPA provider.
 
 == Liquibase changeset
@@ -38,21 +42,22 @@ This is a mutable field due to requirements from the JPA provider.
 .Column
 [source,xml,options="nowrap"]
 ----
-<addColumn tableName="pet">
-    <column name="code" type="BIGINT" defaultValue="0"> <1>
+<addColumn tableName="visit">
+    <column name="duration" type="BIGINT" defaultValueNumeric="0"> <1>
         <constraints nullable="false"/> <2>
     </column>
 </addColumn>
 ----
 
-<1> The column type is `BIGINT` (64-bit integer) with a default value.
+<1> The column type is `BIGINT` and stores the total number of seconds.
+Use a matching numeric default value.
 <2> The column is marked as NOT NULL.
 
 Omit the default value if the field is nullable.
 
 == Property initialization
 
-The property is typically not nullable and initialized to `0L` in the constructor.
+The property is typically not nullable and initialized to a sensible default such as `Duration.ZERO` in the constructor.
 
 The `withId` method must copy the property so that cloned instances remain semantically equal.
 
@@ -66,14 +71,14 @@ Add a setter if a controller must be able to update a property directly.
 [source,java,options="nowrap"]
 ----
 @JsonIgnore <1>
-public Enum setCode(@NonNull final Long code) { <2>
-    this.code = code;
+public Visit setDuration(@NonNull final Duration duration) { <2>
+    this.duration = duration;
     return this; <3>
 }
 ----
 
 <1> The method is marked with `@JsonIgnore` as it is not part of the JSON API.
-<2> The method accepts a `Long` argument.
+<2> The method accepts a `Duration` argument.
 <3> The method returns `this` for operation chaining.
 
 == Property verification
@@ -81,23 +86,21 @@ public Enum setCode(@NonNull final Long code) { <2>
 The property participates in the `isEqual` method comparison.
 Use `Objects#equals`.
 
-Use only the following validation annotations:
+Use only the following validation annotation:
 
-* `@NotNull`: Value must not be null
-* `@Positive`: Value must be greater than 0
-* `@PositiveOrZero`: Value must be 0 or greater
-* `@Min(value)`: Value must be at least the specified minimum
-* `@Max(value)`: Value must not exceed the specified maximum
+* `@NotNull`: Value must not be null.
 
-The `verify` operation may include custom validation logic (e.g., time ranges).
+The `verify` operation may include custom validation logic when required by the domain, e.g. asserting the duration is non-negative.
 
 == Property serialization
 
 The property is by default part of the JSON structure.
+Values are serialized and deserialized as ISO-8601 duration strings (e.g. `"PT1H30M"`).
 
 == `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
+The duration value is provided as an ISO-8601 string literal (e.g. `"PT30M"`).
 
 The `equalsHashcodeToString` test verifies equality operations.
 
@@ -105,23 +108,32 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json{Name}` test verifies the happy path, e.g.
+The `json{Name}` parameterized test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
 - assert property value
 
-Use a parameterized tests if values are distinct.
-
 .Example
 [source,java,options="nowrap"]
 ----
-@Test
-void jsonCode() {
-    final var name = "JIRA";
-    final var value = createWithName(name);
+
+@ParameterizedTest
+@ValueSource(longs = {
+        0,
+        10,
+        -1
+})
+void jsonDuration(final long minutes) {
+    final var value = Visit.fromJson("""
+                    {
+                        "date":"2021-04-22",
+                        "text":"Lorem Ipsum.",
+                        "duration":"%s"
+                    }
+                    """.formatted(Duration.ofMinutes(minutes)));
     assertDoesNotThrow(value::verify);
-    assertEquals(2L, value.getCode());
+    assertEquals(minutes, value.getDuration().toMinutes());
 }
 ----
 
@@ -131,23 +143,23 @@ The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 - invalid values are rejected
 - missing values are rejected
 
-Do not create a test if this properties has no contraints and is nullable.
-
 .Example
 [source,java,options="nowrap"]
 ----
 @ParameterizedTest
 @ValueSource(strings = {
-        "",
-        "-1"
+        "30",
+        "1:30"
 })
-void jsonCodeConstraints(final String text) {
+void jsonDurationConstraints(final String text) {
     final var json = """
                     {
-                        "code":"%s"
+                        "date":"2021-04-22",
+                        "text":"Lorem Ipsum.",
+                        "duration":"%s"
                     }
                     """.formatted(text);
-    assertThrows(IllegalArgumentException.class, () -> Pet.fromJson(json).verify());
+    assertThrows(IllegalArgumentException.class, () -> Visit.fromJson(json).verify());
 }
 ----
 
@@ -160,26 +172,28 @@ A `save{Entity}` test verifies the happy path for a persistence operation.
 ----
 @ParameterizedTest
 @ValueSource(strings = {
-        "Käthe",
-        "Jörg",
-        "Ümit"
+        "Tschüss und schöne Grüße!"
 })
-void savePet(final String name) {
-    final var value0 = createWithName(name);
+void saveVisit(final String text) {
+    final var value0 = createWithText(text);
     assertFalse(value0.isPersisted());
     assertEquals(0L, value0.getVersion());
     assertNotNull(value0.getId());
-    assertNull(value0.getOwner());
+    assertNull(value0.getPet());
+    assertNull(value0.getVet());
     // other assertions
-    assertEquals(42, value0.getCode());
+    assertNotNull(value0.getDuration());
 
-    final var owner = saveOwner("Max Mustermann");
-    final var value1 = petRepository.save(value0.setOwner(owner));
+    final var pet = savePet("Tom");
+    final var vet = saveVet("Dr. Doolittle");
+    final var value1 = visitRepository.save(value0.setPet(pet).setVet(vet));
     assertNotNull(value1);
     assertNotSame(value0, value1);
     assertTrue(value1.isPersisted());
     assertEquals(0L, value1.getVersion());
-    assertNotNull(value1.getOwner());
+    assertNotNull(value1.getId());
+    assertNotNull(value1.getPet());
+    assertNotNull(value1.getVet());
     assertTrue(value1.isEqual(value0));
 }
 ----
@@ -192,52 +206,38 @@ A `queryAll{Entity}` test verifies the happy path for a query operation.
 [source,text,options="nowrap"]
 ----
 @Test
-void queryAllPet() {
-    final var owner = Owner.fromJson("""
-            {
-                "name":"Alice Cooper"
-            }
-            """);
-    final var value = createWithName("Tom")
-            .setOwner(owner);
-    when(petRepository.findAll())
+void queryAllVisit() {
+    final var value = createWithText("Annual checkup");
+    when(visitRepository.findAll())
             .thenReturn(List.of(value));
-    when(ownerRepository.findAllById(anySet()))
-            .thenReturn(List.of(owner));
     final var data = graphQlTester
             .document("""
-                    {allPet{code owner{name}}}
+                    {allVisit{duration}}
                     """)
             .execute();
     assertNotNull(data);
-    data.path("allPet[0].code")
+    data.path("allVisit[0].duration")
             .hasValue()
             .entity(String.class)
-            .isEqualTo(value.getCode());
-    data.path("allPet[0].owner.name")
-            .hasValue()
-            .entity(String.class)
-            .isEqualTo(owner.getName());
-    verify(petRepository).findAll();
-    verifyNoMoreInteractions(petRepository);
-    verify(ownerRepository).findAllById(anySet());
-    verifyNoMoreInteractions(ownerRepository);
+            .isEqualTo(value.getDuration().toString());
+    verify(visitRepository).findAll();
+    verifyNoMoreInteractions(visitRepository);
 }
 ----
 
 == `{Entity}RestApiTest` approach
 
-The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid duration value in the payload.
 Assert the status.
 Assert a non-empty value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid duration value in the payload.
 Assert the status.
 Assert a non-empty value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid duration value in the payload..
 Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
@@ -245,7 +245,6 @@ Create asciidoc snippets for endpoint documentation.
 
 The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
 Use the entity with the primary key from the `putApi{Entity}` test.
-Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.

--- a/doc/concept/spring/_json-jpa-entity-column-enum.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-enum.adoc
@@ -95,7 +95,7 @@ The `verify` operation may include custom validation logic when required by the 
 The property is by default part of the JSON structure.
 Values are serialized as the enum name string.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -105,7 +105,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` parameterized test verifies the happy path, e.g.
+The `json{Name}` parameterized test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -130,7 +130,7 @@ void jsonSex(final Sex sex) {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -157,9 +157,9 @@ void jsonSexConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -190,9 +190,9 @@ void savePet(final String name) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -231,30 +231,26 @@ void queryAllPet() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.

--- a/doc/concept/spring/_json-jpa-entity-column-string.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-string.adoc
@@ -92,7 +92,7 @@ The `verify` operation may include custom validation logic (e.g., time ranges).
 
 The property is by default part of the JSON structure.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -102,7 +102,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` test verifies the happy path, e.g.
+The `json{Name}` test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -126,7 +126,7 @@ void jsonName() {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -154,9 +154,9 @@ void jsonNameConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -184,9 +184,9 @@ void saveVet(final String name) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -211,30 +211,26 @@ void queryAllVet() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.

--- a/doc/concept/spring/_json-jpa-entity-column-time.adoc
+++ b/doc/concept/spring/_json-jpa-entity-column-time.adoc
@@ -98,7 +98,7 @@ The `verify` operation may include custom validation logic (e.g., time ranges).
 
 The property is by default part of the JSON structure.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 The date value is provided as a string literal in `HH:mm` format matching `TIME_PATTERN`.
@@ -109,7 +109,7 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-The `json<Name>` parameterized test verifies the happy path, e.g.
+The `json{Name}` parameterized test verifies the happy path, e.g.
 
 - `verify` does not throw an exception
 - correct deserialization from JSON
@@ -134,7 +134,7 @@ void jsonTime(final LocalTime time) {
 }
 ----
 
-The `json<Name>Constraints` parameterized test verifies constraints, e.g.
+The `json{Name}Constraints` parameterized test verifies constraints, e.g.
 
 - `verify` throws an exception
 - invalid values are rejected
@@ -160,9 +160,9 @@ void jsonTimeConstraints(final String text) {
 }
 ----
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -195,9 +195,9 @@ void saveVisit(final String text) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 
 .Example
 [source,text,options="nowrap"]
@@ -222,30 +222,26 @@ void queryAllVisit() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
+Assert the status.
+Assert a non-empty value of the property in the response.
+Create asciidoc snippets for endpoint documentation.
+
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
 Assert the value of the property in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Create asciidoc snippets for endpoint documentation.
-
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new property in the payload for the request.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the new property in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
-Assert the status.
-Assert the value of the property in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
 Assert the value of the property in the response.

--- a/doc/concept/spring/_json-jpa-entity-relation-many-to-one.adoc
+++ b/doc/concept/spring/_json-jpa-entity-relation-many-to-one.adoc
@@ -153,7 +153,7 @@ protected void extraJson(@NonNull final Map<String, Object> allExtra) {
 <1> Callback from the base operation with `@JsonAnyGetter` annotation.
 <2> The parent entity is converted to a simple state transfer object.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 Create fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
@@ -166,9 +166,9 @@ The `withId` test verifies cloning.
 The `writeJson` test verifies serialisation to JSON.
 relations must always be absent from the JSON structure.
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 Persist fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
 
 .Example
@@ -199,9 +199,9 @@ void savePet(final String name) {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 Create fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
 
 .Example
@@ -241,40 +241,31 @@ void queryAllPet() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the relation in the payload for the request.
-Annotate the test with `@Sql` annotations for each SQL fixture file needed to provide the referenced entity.
-Assert the status.
-Assert the value of the  relation in the response.
-Create asciidoc snippets for endpoint documentation.
+Annotate the `getApi{Entity}NoElement` test with `@Sql` annotations for each SQL fixture file needed to provide referenced entities.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the relation in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the relation in the payload for the request.
 Assert the status.
 Create asciidoc snippets for endpoint documentation.
 
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the relation in the payload for the request.
-Assert the status.
-Assert the value of the  relation in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the relation in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the relation in the payload for the request.
 Assert the status.
 Create asciidoc snippets for endpoint documentation.
 
-Add `getApi<Entity><Name>` test.
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the relation in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
+Assert the status.
+Create asciidoc snippets for endpoint documentation.
+
+Add `getApi{Entity}{Name}` test.
 The test verifies the happy path of the GET entity operation for the relation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
-Assert the value of the relation in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the `ETag` value according to the new test.
 Assert the status.
-Assert the value of the relation in the response.
 Create asciidoc snippets for endpoint documentation.
-
-The `cleanup` method must delete all entities in reverse foreign key order to avoid constraint violations.

--- a/doc/concept/spring/_json-jpa-entity-relation-one-to-many.adoc
+++ b/doc/concept/spring/_json-jpa-entity-relation-one-to-many.adoc
@@ -85,7 +85,7 @@ protected void extraJson(@NonNull final Map<String, Object> allExtra) {
 <1> Callback from the base operation with `@JsonAnyGetter` annotation.
 <2> All child entities are converted to a simple state transfer object.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -96,14 +96,14 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
 Do not create a test specifically for this property.
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
 Do not create a test specifically for this property.
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
 Do not create a test specifically for this property.

--- a/doc/concept/spring/_json-jpa-entity-relation-one-to-one.adoc
+++ b/doc/concept/spring/_json-jpa-entity-relation-one-to-one.adoc
@@ -162,7 +162,7 @@ protected void extraJson(@NonNull final Map<String, Object> allExtra) {
 <2> The Owner entity is converted to a simple state transfer object.
 This does break lazy loading, but it makes sense because the recipient is always needed.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 Create fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
@@ -174,9 +174,9 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
-A `save<Entity>` test verifies the happy path for a persistence operation.
+A `save{Entity}` test verifies the happy path for a persistence operation.
 Persist fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
 
 .Example
@@ -206,7 +206,7 @@ void saveInvoice(final String text) {
 }
 ----
 
-A `save<Entity>UniqueContraint` verifies the unique constraint.
+A `save{Entity}UniqueContraint` verifies the unique constraint.
 
 .Example
 [source,text,options="nowrap"]
@@ -224,9 +224,9 @@ void saveInvoiceUniqueConstraint() {
 }
 ----
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
-A `queryAll<Entity>` test verifies the happy path for a query operation.
+A `queryAll{Entity}` test verifies the happy path for a query operation.
 Create fixtures parameterized with the unique keys needed to provide referenced required entities with a fixed primary key value.
 
 .Example
@@ -258,40 +258,31 @@ void queryAllInvoice() {
 }
 ----
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
-The `postApi<Entity>` test verifies the happy path of the POST entity operation with a valid value for the new relation in the payload for the request.
-Annotate the test with `@Sql` annotations for each SQL fixture file needed to provide the referenced entity.
-Assert the status.
-Assert the value of the relation in the response.
-Create asciidoc snippets for endpoint documentation.
+Annotate the `getApi{Entity}NoElement` test with `@Sql` annotations for each SQL fixture file needed to provide referenced entities.
 
-The `postApi<Entity>Conflict` test verifies the error path with unique key constraints of the POST entity operation with a valid value for the relation in the payload for the request.
+The `postApi{Entity}` test verifies the happy path of the POST entity operation with a valid value for the new relation in the payload for the request.
 Assert the status.
 Create asciidoc snippets for endpoint documentation.
 
-The `putApi<Entity>` test verifies the happy path of the PUT entity operation with a valid value for the new relation in the payload for the request.
-Assert the status.
-Assert the value of the relation in the response.
-Create asciidoc snippets for endpoint documentation.
-
-The `patchApi<Entity><Name>` test verifies the happy path of the PATCH entity operation with a valid value for the relation in the payload for the request.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `putApi{Entity}` test verifies the happy path of the PUT entity operation with a valid value for the new relation in the payload for the request.
 Assert the status.
 Create asciidoc snippets for endpoint documentation.
 
-Add `getApi<Entity><Name>` test.
+The `patchApi{Entity}{Name}` test verifies the happy path of the PATCH entity operation with a valid value for the relation in the payload for the request.
+Use the entity with the primary key from the `putApi{Entity}` test.
+Assert the status.
+Create asciidoc snippets for endpoint documentation.
+
+Add `getApi{Entity}{Name}` test.
 The test verifies the happy path of the GET entity operation for the relation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Assert the status.
-Assert the value of the relation in the response.
 Create asciidoc snippets for endpoint documentation.
 
-The `getApi<Entity>ById` test verifies the happy path of the GET entity operation.
-Use the entity with the primary key from the `putApi<Entity>` test.
+The `getApi{Entity}ById` test verifies the happy path of the GET entity operation.
+Use the entity with the primary key from the `putApi{Entity}` test.
 Compute the new `ETag` value according to the new test.
 Assert the status.
-Assert the value of the relation in the response.
 Create asciidoc snippets for endpoint documentation.
-
-The `cleanup` method must delete all entities in reverse foreign key order to avoid constraint violations.

--- a/doc/concept/spring/_json-jpa-entity-version-id.adoc
+++ b/doc/concept/spring/_json-jpa-entity-version-id.adoc
@@ -93,7 +93,7 @@ The properties must not be verified.
 
 The properties are by default part of the JSON structure.
 
-== `<Entity>Test` approach
+== `{Entity}Test` approach
 
 Create test data from JSON using `fromJson` method of entity classes.
 
@@ -103,14 +103,14 @@ The `withId` test verifies cloning.
 
 The `writeJson` test verifies serialisation to JSON.
 
-== `<Entity>RepositoryTest` approach
+== `{Entity}RepositoryTest` approach
 
 Do not create a test specifically for these properties.
 
-== `<Entity>GraphqlTest` approach
+== `{Entity}GraphqlTest` approach
 
 Do not create a test specifically for these properties.
 
-== `<Entity>RestApiTest` approach
+== `{Entity}RestApiTest` approach
 
 Do not create a test specifically for these properties.

--- a/doc/service/visit-graphql.adoc
+++ b/doc/service/visit-graphql.adoc
@@ -24,6 +24,9 @@ The property `date` uses the custom scalar type `LocalDate` which maps to Java's
 
 The property `time` uses the custom scalar type `LocalTime` which maps to Java's `java.time.LocalTime` type for representing times of day with format `HH:mm[:ss]` (seconds are optional).
 
+The property `duration` is exposed as `String!` in GraphQL and maps to Java's `java.time.Duration`.
+The value uses ISO-8601 duration notation (e.g. `PT45M`, `PT1H30M`).
+
 The relation `pet` uses batch loading via `@BatchMapping` to efficiently load pets for multiple visits.
 Visits without a pet assigned resolve `pet` relation as `null`.
 

--- a/doc/service/visit-restapi.adoc
+++ b/doc/service/visit-restapi.adoc
@@ -4,7 +4,7 @@
 = Visit REST API
 
 REST-API for managing veterinary visits in the pet clinic application.
-It provides standard CRUD operations, partial updates via PATCH, and advanced query capabilities for filtering visits by date, pet, veterinarian, and text content.
+It provides standard CRUD operations, partial updates via PATCH, and advanced query capabilities for filtering visits by date, pet, veterinarian, text content, and treatment duration.
 
 == Model
 
@@ -154,7 +154,7 @@ This operation reports `Conflict` or code 409 if a unique constraint would be vi
 
 This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
 
-TIP: The descriptions of attributes other than `date` are omitted for simplicity because they are following the same pattern (e.g. `time`, `text`, `billable`).
+TIP: The descriptions of attributes other than `date` are omitted for simplicity because they are following the same pattern (e.g. `time`, `text`, `billable`, `duration`).
 
 ==== `pet` relation
 
@@ -229,8 +229,8 @@ Find visits with specific vet
 Find visits with text containing "Lorem" (case-insensitive)
 `?text=Lorem%`::
 Find visits with text starting with "Lorem" (case-insensitive)
-
-NOTE: The `billable` field supports exact-match filtering via the default Querydsl binding (e.g. `?billable=true`). Consider documenting this parameter with an explicit example.
+`?duration=PT45M`::
+Find visits with exact treatment duration of 45 minutes
 
 This operation supports sorting, e.g.
 

--- a/lib/backend-api/src/main/java/esy/api/clinic/Visit.adoc
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Visit.adoc
@@ -1,7 +1,8 @@
 A `Visit` entity represents a veterinary treatment for a pet.
 The treatment `date` is required.
 The treatment `time` is optional because it only becomes definitive once treatment begins.
-The diagnosis `text` is optional because it is only written at the end of the treatment.
+The treatment `duration` is required and only becomes definitive at the end of the treatment.
+The diagnosis `text` is required and only becomes definitive at the end of the treatment.
 The `billable` flag indicates whether the visit is subject to billing and defaults to `false`.
 The `pet` relation is optional because visits can be created as placeholders for veterinarians on duty.
 The `vet` relation is optional because the veterinarian on duty is not always known at the time the visit is created.

--- a/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import esy.api.client.OwnerItem;
 import esy.api.client.Pet;
 import esy.api.client.PetItem;
+import esy.jpa.DurationConverter;
 import esy.rest.JsonJpaEntity;
 import esy.rest.JsonJpaMapper;
 import lombok.Getter;
@@ -13,6 +14,7 @@ import lombok.NonNull;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -72,6 +74,13 @@ public final class Visit extends JsonJpaEntity<Visit> {
     @Getter
     @JsonProperty
     private boolean billable;
+
+    @Column(name = "duration")
+    @Getter
+    @JsonProperty
+    @JsonFormat(shape = JsonFormat.Shape.STRING)
+    @Convert(converter = DurationConverter.class)
+    private Duration duration;
     // end::properties[]
 
     Visit() {
@@ -82,6 +91,7 @@ public final class Visit extends JsonJpaEntity<Visit> {
         this.pet = null;
         this.vet = null;
         this.billable = false;
+        this.duration = Duration.ZERO;
     }
 
     Visit(@NonNull final Long version, @NonNull final UUID id) {
@@ -92,6 +102,7 @@ public final class Visit extends JsonJpaEntity<Visit> {
         this.pet = null;
         this.vet = null;
         this.billable = false;
+        this.duration = Duration.ZERO;
     }
 
     @Override
@@ -112,7 +123,8 @@ public final class Visit extends JsonJpaEntity<Visit> {
                 Objects.equals(this.text, that.text) &&
                 Objects.equals(this.pet, that.pet) &&
                 Objects.equals(this.vet, that.vet) &&
-                this.billable == that.billable;
+                this.billable == that.billable &&
+                Objects.equals(this.duration, that.duration);
     }
 
     @Override
@@ -127,6 +139,7 @@ public final class Visit extends JsonJpaEntity<Visit> {
         value.pet = this.pet;
         value.vet = this.vet;
         value.billable = this.billable;
+        value.duration = this.duration;
         return value;
     }
 

--- a/lib/backend-api/src/main/java/esy/jpa/DurationConverter.java
+++ b/lib/backend-api/src/main/java/esy/jpa/DurationConverter.java
@@ -1,0 +1,19 @@
+package esy.jpa;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.time.Duration;
+
+@Converter(autoApply = true)
+public class DurationConverter implements AttributeConverter<Duration, Long> {
+
+    @Override // <1>
+    public Long convertToDatabaseColumn(final Duration value) {
+        return value == null ? null : value.getSeconds();
+    }
+
+    @Override // <2>
+    public Duration convertToEntityAttribute(final Long value) {
+        return value == null ? null : Duration.ofSeconds(value);
+    }
+}

--- a/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
@@ -92,6 +93,7 @@ class VisitTest {
         assertFalse(json.at("/date").isMissingNode());
         assertFalse(json.at("/time").isMissingNode());
         assertFalse(json.at("/billable").isMissingNode());
+        assertFalse(json.at("/duration").isMissingNode());
     }
 
     @Test
@@ -102,6 +104,7 @@ class VisitTest {
         assertNotNull(value0.getDate());
         assertNotNull(value0.getTime());
         assertFalse(value0.isBillable());
+        assertNotNull(value0.getDuration());
         assertNotNull(value0.getPet());
         assertNotNull(value0.getVet());
         final var value1 = value0.withId(value0.getId());
@@ -227,6 +230,49 @@ class VisitTest {
                             "date":"2021-04-22",
                             "time":"%s",
                             "text":"Lorem Ipsum."
+                        }
+                        """.formatted(text);
+        assertThrows(IllegalArgumentException.class, () -> Visit.fromJson(json).verify());
+    }
+
+    static Stream<Duration> jsonDuration() {
+        return Stream.of(
+                Duration.ZERO,
+                Duration.ofMinutes(30),
+                Duration.ofHours(1),
+                Duration.ofHours(1).plusMinutes(30)
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {
+            0,
+            10,
+            -1
+    })
+    void jsonDuration(final long minutes) {
+        final var value = Visit.fromJson("""
+                        {
+                            "date":"2021-04-22",
+                            "text":"Lorem Ipsum.",
+                            "duration":"%s"
+                        }
+                        """.formatted(Duration.ofMinutes(minutes)));
+        assertDoesNotThrow(value::verify);
+        assertEquals(minutes, value.getDuration().toMinutes());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "30",
+            "1:30"
+    })
+    void jsonDurationConstraints(final String text) {
+        final var json = """
+                        {
+                            "date":"2021-04-22",
+                            "text":"Lorem Ipsum.",
+                            "duration":"%s"
                         }
                         """.formatted(text);
         assertThrows(IllegalArgumentException.class, () -> Visit.fromJson(json).verify());

--- a/lib/backend-data/src/main/resources/graphql/Visit.gqls
+++ b/lib/backend-data/src/main/resources/graphql/Visit.gqls
@@ -4,6 +4,7 @@ type Visit {
     time: LocalTime
     text: String
     billable: Boolean!
+    duration: String!
     pet: Pet
     vet: Vet
 }

--- a/lib/backend-data/src/main/resources/liquibase/v1/visit.xml
+++ b/lib/backend-data/src/main/resources/liquibase/v1/visit.xml
@@ -61,4 +61,11 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="4" author="robert">
+        <addColumn tableName="visit">
+            <column name="duration" type="BIGINT" defaultValueNumeric="0">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
@@ -77,7 +77,7 @@ class VisitGraphqlTest {
         when(visitRepository.findAll())
                 .thenReturn(List.of(value));
         final var data = graphQlTester
-                .document("{allVisit{text billable}}")
+                .document("{allVisit{text billable duration}}")
                 .execute();
         assertNotNull(data);
         data.path("allVisit[0].text")
@@ -88,6 +88,10 @@ class VisitGraphqlTest {
                 .hasValue()
                 .entity(Boolean.class)
                 .isEqualTo(value.isBillable());
+        data.path("allVisit[0].duration")
+                .hasValue()
+                .entity(String.class)
+                .isEqualTo(value.getDuration().toString());
         verify(visitRepository).findAll();
         verifyNoMoreInteractions(visitRepository);
         verifyNoInteractions(petRepository);

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitRepositoryTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitRepositoryTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.UUID;
 
@@ -90,6 +91,7 @@ public class VisitRepositoryTest {
         assertNotNull(value0.getDate());
         assertNotNull(value0.getTime());
         assertFalse(value0.isBillable());
+        assertNotNull(value0.getDuration());
         assertNull(value0.getPet());
         assertNull(value0.getVet());
 

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.UUID;
@@ -408,6 +409,34 @@ class VisitRestApiTest {
     }
 
     @Test
+    @Order(408)
+    void patchApiVisitDuration() throws Exception {
+        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(visitRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/visit/" + uuid)
+                        .content("""
+                                {
+                                    "duration":"PT30S"
+                                }
+                                """)
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .string("ETag", "\"7\""))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.duration")
+                        .value("PT30S"));
+    }
+
+    @Test
     @Order(500)
     void getApiVisit() throws Exception {
         assertEquals(4, visitRepository.count());
@@ -450,7 +479,7 @@ class VisitRestApiTest {
                 .andExpect(header()
                         .exists("Vary"))
                 .andExpect(header()
-                        .string("ETag", "\"6\""))
+                        .string("ETag", "\"7\""))
                 .andExpect(jsonPath("$.id")
                         .value(value.getId().toString()))
                 .andExpect(jsonPath("$.date")
@@ -460,7 +489,9 @@ class VisitRestApiTest {
                 .andExpect(jsonPath("$.text")
                         .value(value.getText()))
                 .andExpect(jsonPath("$.billable")
-                        .value(true));
+                        .value(true))
+                .andExpect(jsonPath("$.duration")
+                        .value(value.getDuration().toString()));
     }
 
     @Test


### PR DESCRIPTION
## Add a new implementation guide _json-jpa-entity-column-duration.adoc for a entity property of type java.time.Duration

Created _json-jpa-entity-column-duration.adoc. The guide covers:

- **Default implementation** — field annotations (`@NotNull`, `@Column`, `@Getter`, `@JsonProperty`, `@JsonSerialize`/`@JsonDeserialize`, `@Convert`)
- **JPA converter** — `DurationConverter` mapping `Duration` ↔ `Long` (total seconds)
- **Liquibase changeset** — `BIGINT` column storing total seconds
- **Property initialization/manipulation/verification** — including setter pattern with `@JsonIgnore`
- **Serialization** — ISO-8601 strings (e.g. `"PT1H30M"`) in the REST/GraphQL API
- **Test approaches** — `<Entity>Test`, `<Entity>RepositoryTest`, `<Entity>GraphqlTest`, `<Entity>RestApiTest` sections with code examples following the same conventions as the other column guides 

## Add a duration property to the Visit entity

Here's a summary of all changes made:

### New file
- DurationConverter.java — JPA `AttributeConverter<Duration, Long>` mapping duration to total seconds

#### Modified files
- Visit.java — `@NotNull @JsonProperty @JsonFormat(STRING) @Convert duration` field; initialized to `Duration.ZERO` in both constructors; included in `isEqual` and `withId`
- visit.xml — changeset `id="4"` adds `duration BIGINT NOT NULL DEFAULT 0`
- Visit.gqls — added `duration: String!`
- VisitTest.java — `duration` in `writeJson`/`withId`; added `jsonDuration` and `jsonDurationConstraints` tests
- VisitRepositoryTest.java — `assertEquals(Duration.ZERO, value0.getDuration())` in `saveVisit`
- VisitGraphqlTest.java — `duration` in query and assertion
- VisitRestApiTest.java — added `patchApiVisitDuration` at `@Order(408)` (ETag `"7"`); updated `getApiVisitById` ETag to `"7"` with `duration` assertion 

## Update REST API and GraphQL API documentation for the new property duration in entity Visit

Updated the REST and GraphQL documentation for Visit duration and aligned the shared Visit model description used by both docs.

### Added duration coverage in REST documentation: visit-restapi.adoc
- Extended the API overview to include treatment duration filtering.
- Updated PATCH guidance to include duration as a standard attribute update.
- Added duration query example using ISO-8601 format (PT45M).
- Updated filtering note to include exact-match duration filtering.

### Added duration coverage in GraphQL documentation: visit-graphql.adoc
- Documented that duration is exposed as String! and maps to java.time.Duration.
- Added ISO-8601 examples (PT45M, PT1H30M).
- Clarified non-null behavior and converter-based persistence.

### Synced the shared Visit model fact sheet: Visit.adoc
- Added required duration description and ISO-8601 representation note.

## Update Svelte and Angular frontend

### Add time and duration of entity Visit to the diagnosis editor in the svelte and angular client. Put time and duration in one line with media break sm, stack it otherwise.

### Add date and time of entity Visit to the treatment editor in the svelte and angular client. Put date and time in one line with media break sm, stack it otherwise.

### Add date, time and duration of the Visit entity to the visit overview n the svelte and angular client. Put date, time and duration in one line with media break sm, stack it otherwise.

### For duration add input fields for hours, minutes and seconds derived from the ISO-8601 string (e.g. "PT1H30M").

### In the visit overview show a text with an interpretation of the duration value, e.g. PT30M leads to 30 minutes or PT1H35M leads to 1 hour 35 minutes or PT3H20M10S to 3 hours 20 minutes 10 seconds

### Extend the VisitListerPage. Add a mutation and expectation for time and duration in the updateDiagnose method. 

### Extend the PetListerPage. Add a mutation and expectation for date and time in the createVisit  method.
