### PR TITLE
feat: Schema konfigurierbar für PostgreSQL

### DIFF
--- a/app/client-angular/package-lock.json
+++ b/app/client-angular/package-lock.json
@@ -3293,9 +3293,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3313,9 +3310,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9065,9 +9059,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9085,9 +9076,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9105,9 +9093,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9125,9 +9110,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/app/deploy/compose-pg.yml
+++ b/app/deploy/compose-pg.yml
@@ -18,7 +18,8 @@ services:
     environment:
       - _JAVA_OPTIONS=-Xdebug -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
       - SERVER_PORT=8080
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres
+      - DATABASE_SCHEMA=${COMPOSE_PROJECT_NAME}
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres?currentSchema=${COMPOSE_PROJECT_NAME}
       - SPRING_DATASOURCE_USERNAME=sa
       - SPRING_DATASOURCE_PASSWORD=P@ssw0rd
       - SPRING_LIQUIBASE_ENABLED=false
@@ -31,7 +32,8 @@ services:
     hostname: migrate
     image: ${COMPOSE_PROJECT_NAME}/migrate
     environment:
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres
+      - DATABASE_SCHEMA=${COMPOSE_PROJECT_NAME}
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres17:5432/postgres?currentSchema=${COMPOSE_PROJECT_NAME}
       - SPRING_DATASOURCE_USERNAME=sa
       - SPRING_DATASOURCE_PASSWORD=P@ssw0rd
       - SPRING_LIQUIBASE_CHANGE_LOG=liquibase/changelog.xml

--- a/app/migrate/src/main/java/esy/migrate/MigrateRunner.java
+++ b/app/migrate/src/main/java/esy/migrate/MigrateRunner.java
@@ -13,17 +13,21 @@ public final class MigrateRunner {
     private MigrateRunner() {
     }
 
-    public static void main(final String[] args) throws Exception {
+    static void main(final String[] args) {
         try {
+            final var schema = requireEnv("DATABASE_SCHEMA");
             final var jdbcUrl = requireEnv("SPRING_DATASOURCE_URL");
             final var username = requireEnv("SPRING_DATASOURCE_USERNAME");
             final var password = requireEnv("SPRING_DATASOURCE_PASSWORD");
             final var changeLog = requireEnv("SPRING_LIQUIBASE_CHANGE_LOG");
             final var accessor = new ClassLoaderResourceAccessor(MigrateRunner.class.getClassLoader());
             try (final var connection = DriverManager.getConnection(jdbcUrl, username, password)) {
+                try (final var statement = connection.createStatement()) {
+                    statement.execute(String.format("CREATE SCHEMA IF NOT EXISTS \"%s\"", schema));
+                }
                 final var database = DatabaseFactory.getInstance()
                         .findCorrectDatabaseImplementation(new JdbcConnection(connection));
-                try (var liquibase = new Liquibase(changeLog, accessor, database)) {
+                try (final var liquibase = new Liquibase(changeLog, accessor, database)) {
                     liquibase.update(new Contexts(), new LabelExpression());
                 }
             }

--- a/lib/backend-data/src/main/resources/database.properties
+++ b/lib/backend-data/src/main/resources/database.properties
@@ -1,11 +1,15 @@
+database.schema=PUBLIC
 # org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties
 spring.liquibase.enabled=true
+spring.liquibase.default-schema=${database.schema}
+spring.liquibase.liquibase-schema=${database.schema}
 spring.liquibase.change-log=classpath:liquibase/changelog.xml
 # org.springframework.boot.autoconfigure.jdbc.DatasourceProperties
 spring.datasource.url=jdbc:hsqldb:mem:db;DB_CLOSE_DELAY=-1
 spring.datasource.username=SA
 spring.datasource.password=
 # org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+spring.jpa.properties.hibernate.default_schema=${database.schema}
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.generate_statistics=true

--- a/lib/backend-data/src/main/resources/database.properties
+++ b/lib/backend-data/src/main/resources/database.properties
@@ -1,14 +1,14 @@
 database.schema=PUBLIC
-# org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties
+# org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties
 spring.liquibase.enabled=true
 spring.liquibase.default-schema=${database.schema}
 spring.liquibase.liquibase-schema=${database.schema}
 spring.liquibase.change-log=classpath:liquibase/changelog.xml
-# org.springframework.boot.autoconfigure.jdbc.DatasourceProperties
+# org.springframework.boot.jdbc.autoconfigure.DataSourceProperties
 spring.datasource.url=jdbc:hsqldb:mem:db;DB_CLOSE_DELAY=-1
 spring.datasource.username=SA
 spring.datasource.password=
-# org.springframework.boot.autoconfigure.orm.jpa.HibernateProperties
+# org.springframework.boot.hibernate.autoconfigure.HibernateProperties
 spring.jpa.properties.hibernate.default_schema=${database.schema}
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
@@ -18,5 +18,5 @@ spring.jpa.properties.hibernate.order_inserts=true
 spring.jpa.properties.hibernate.order_updates=true
 spring.jpa.properties.hibernate.batch_versioned_data=true
 spring.jpa.properties.org.hibernate.envers.store_data_at_delete=true
-# org.springframework.boot.autoconfigure.orm.jpa.JpaProperties
+# org.springframework.boot.jpa.autoconfigure.JpaProperties
 spring.jpa.open-in-view=false

--- a/lib/backend-data/src/main/resources/endpoint.properties
+++ b/lib/backend-data/src/main/resources/endpoint.properties
@@ -1,12 +1,12 @@
-# org.springframework.boot.autoconfigure.web.ServerProperties
+# org.springframework.boot.web.server.autoconfigure.ServerProperties
 server.port=8080
 server.compression.enabled=false
-# org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties
+# org.springframework.boot.data.autoconfigure.web.DataWebProperties
 # tag::restapi[]
 spring.data.web.pageable.default-page-size=9999
 spring.data.web.pageable.max-page-size=9999
 # end::restapi[]
-# org.springframework.boot.autoconfigure.data.rest.RepositoryRestProperties
+# org.springframework.boot.data.rest.autoconfigure.DataRestProperties
 # tag::restapi[]
 spring.data.rest.default-page-size=9999
 spring.data.rest.max-page-size=9999
@@ -15,7 +15,7 @@ spring.data.rest.max-page-size=9999
 # tag::management[]
 management.endpoints.web.exposure.include=health
 # end::management[]
-# org.springframework.boot.actuate.autoconfigure.health.HealthEndpointProperties
+# org.springframework.boot.health.autoconfigure.actuate.endpoint.HealthEndpointProperties
 # tag::management[]
 management.endpoint.health.probes.enabled=true
 # end::management[]

--- a/lib/backend-data/src/main/resources/graphql.properties
+++ b/lib/backend-data/src/main/resources/graphql.properties
@@ -1,4 +1,4 @@
-# org.springframework.boot.autoconfigure.graphql.GraphQlProperties
+# org.springframework.boot.graphql.autoconfigure.GraphQlProperties
 # tag::graphql[]
 spring.graphql.http.path=/api/graphql
 spring.graphql.graphiql.path=/api/graphiql

--- a/lib/backend-data/src/test/java/esy/app/EsyBackendConfigurationTest.java
+++ b/lib/backend-data/src/test/java/esy/app/EsyBackendConfigurationTest.java
@@ -5,7 +5,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.data.autoconfigure.web.DataWebProperties;
+import org.springframework.boot.data.rest.autoconfigure.DataRestProperties;
+import org.springframework.boot.graphql.autoconfigure.GraphQlProperties;
+import org.springframework.boot.health.autoconfigure.actuate.endpoint.HealthEndpointProperties;
+import org.springframework.boot.hibernate.autoconfigure.HibernateProperties;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceProperties;
+import org.springframework.boot.jpa.autoconfigure.JpaProperties;
+import org.springframework.boot.liquibase.autoconfigure.LiquibaseProperties;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.autoconfigure.ServerProperties;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.io.ResourceLoader;
@@ -15,9 +26,13 @@ import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Tag("slow")
 @SpringBootTest
+@EnableConfigurationProperties({
+		DataWebProperties.class,
+		DataRestProperties.class})
 public class EsyBackendConfigurationTest {
 
 	@Autowired
@@ -29,6 +44,36 @@ public class EsyBackendConfigurationTest {
 	@Autowired
 	private ResourceLoader resourceLoader;
 
+	@Autowired
+	private ServerProperties serverProperties;
+
+	@Autowired
+	private HealthEndpointProperties healthEndpointProperties;
+
+	@Autowired
+	private WebEndpointProperties webEndpointProperties;
+
+	@Autowired
+	private DataWebProperties dataWebProperties;
+
+	@Autowired
+	private DataRestProperties dataRestProperties;
+
+	@Autowired
+	private LiquibaseProperties liquibaseProperties;
+
+	@Autowired
+	private DataSourceProperties datasourceProperties;
+
+	@Autowired
+	private HibernateProperties hibernateProperties;
+
+	@Autowired
+	private JpaProperties jpaProperties;
+
+	@Autowired
+	private GraphQlProperties graphQlProperties;
+
 	@Test
 	void context() {
 		assertNotNull(context);
@@ -39,6 +84,45 @@ public class EsyBackendConfigurationTest {
 		assertNotNull(context.getBean(EsyGraphqlConfiguration.class));
 		assertNotNull(context.getBean(EsySecurityConfiguration.class));
 		assertNotNull(context.getBean(CollectionModelProcessor.class));
+	}
+
+	@Test
+	void endpointProperties() {
+		assertNotNull(serverProperties);
+		assertFalse(serverProperties.getCompression().getEnabled());
+		assertNotNull(healthEndpointProperties);
+		assertNotNull(webEndpointProperties);
+		assertNotNull(dataWebProperties);
+		assertEquals(9999, dataWebProperties.getPageable().getDefaultPageSize());
+		assertEquals(9999, dataWebProperties.getPageable().getMaxPageSize());
+		assertNotNull(dataRestProperties);
+		assertEquals(9999, dataRestProperties.getDefaultPageSize());
+		assertEquals(9999, dataRestProperties.getMaxPageSize());
+	}
+
+	@Test
+	void databaseProperties() {
+		assertNotNull(liquibaseProperties);
+		assertTrue(liquibaseProperties.isEnabled());
+		assertEquals("PUBLIC", liquibaseProperties.getDefaultSchema());
+		assertEquals("PUBLIC", liquibaseProperties.getLiquibaseSchema());
+		assertEquals("classpath:liquibase/changelog.xml", liquibaseProperties.getChangeLog());
+		assertNotNull(datasourceProperties);
+		assertEquals("jdbc:hsqldb:mem:db;DB_CLOSE_DELAY=-1", datasourceProperties.getUrl());
+		assertEquals("SA", datasourceProperties.getUsername());
+		assertEquals("", datasourceProperties.getPassword());
+		assertNotNull(hibernateProperties);
+		assertNull(hibernateProperties.getDdlAuto());
+		assertNotNull(jpaProperties);
+		assertEquals(Boolean.FALSE, jpaProperties.getOpenInView());
+	}
+
+	@Test
+	void graphqlProperties() {
+		assertNotNull(graphQlProperties);
+		assertEquals("/api/graphql", graphQlProperties.getHttp().getPath());
+		assertEquals("/api/graphiql", graphQlProperties.getGraphiql().getPath());
+		assertTrue(graphQlProperties.getGraphiql().isEnabled());
 	}
 
 	@Test


### PR DESCRIPTION
## Portable schema setup

- Configure it via env var DATABASE_SCHEMA
- Be aware of default schema names:
  * PostgreSQL: public
  * HyperSQL: PUBLIC, case-sensitiv 
- Set it in database.properties
  * Liquibase: default-schema + liquibase-schema
  * Hibernate: hibernate.default_schema
- Set it in database session
  * PostgreSQL: ?currentSchema=${database.schema}
  * HyperSQL: SET SCHEMA ${database.schema}
- Create schema explicitly
