### PR TITLE
example: DACH CoP Data & AI (DO NOT MERGE)

### DIFF
--- a/doc/service/vet-graphql.adoc
+++ b/doc/service/vet-graphql.adoc
@@ -15,6 +15,7 @@ include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Vet.adoc[]
 NOTE: The `vet_skill` and `vet_species` database tables (see `vet_skill.xml` and `vet_species.xml`) do not have a unique constraint on the `(id, skill)` or `(id, species)` column pairs. Uniqueness is enforced at the application layer via `SortedSet<String>` in the Java entity. Consider adding a database-level unique constraint to prevent duplicate entries if data is ever inserted directly via SQL.
 
 The schema type `Vet` defines properties, collections and relations.
+The property `retired` marks veterinarians that are no longer active.
 
 .Schema
 [source,graphql,options="nowrap"]

--- a/doc/service/vet-restapi.adoc
+++ b/doc/service/vet-restapi.adoc
@@ -124,7 +124,7 @@ This operation reports `Conflict` or code 409 if a unique constraint would be vi
 
 This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
 
-TIP: The descriptions of attributes other than name are omitted for simplicity because they are following the same pattern.
+TIP: The descriptions of attributes other than `name` are omitted for simplicity because they follow the same pattern (e.g. `retired`).
 
 ==== `allSkill` collection
 

--- a/doc/service/visit-restapi.adoc
+++ b/doc/service/visit-restapi.adoc
@@ -55,6 +55,7 @@ include::{includedir}/lib/backend-api/src/main/java/esy/api/clinic/Vet.adoc[]
 
 The entity class `Vet` is referenced.
 The vet conducts the treatment.
+Retired vets are still visible in existing visit data, but new visits cannot be assigned to them.
 
 .Entity
 [source,java,options="nowrap"]

--- a/doc/service/visit-restapi.adoc
+++ b/doc/service/visit-restapi.adoc
@@ -154,7 +154,7 @@ This operation reports `Conflict` or code 409 if a unique constraint would be vi
 
 This operation reports `Precondition Failed` or code 412 if data is outdated (invalid ETag).
 
-TIP: The descriptions of attributes other than `date` are omitted for simplicity because they are following the same pattern (e.g. `time`, `text`, `billable`, `duration`).
+TIP: The descriptions of attributes other than `date` are omitted for simplicity because they are following the same pattern (e.g. `time`, `text`, `duration`).
 
 ==== `pet` relation
 

--- a/lib/backend-api/src/main/java/esy/api/clinic/Vet.adoc
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Vet.adoc
@@ -1,4 +1,5 @@
 A `Vet` entity represents a veterinarian working at the pet clinic.
 The `name` attribute is required and unique.
+The `retired` attribute is a non-null boolean flag that marks vets who are no longer active and cannot be assigned to visits.
 The `allSkill` collection is a sorted set of unique strings and may be empty.
 The `allSpecies` collection is a sorted set of unique strings and may be empty.

--- a/lib/backend-api/src/main/java/esy/api/clinic/Vet.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Vet.java
@@ -25,6 +25,11 @@ public final class Vet extends JsonJpaEntity<Vet> {
     @JsonProperty
     private String name;
 
+    @Column(name = "retired")
+    @Getter
+    @JsonProperty
+    private boolean retired;
+
     @ElementCollection(
             fetch = FetchType.EAGER)
     @CollectionTable(
@@ -49,6 +54,7 @@ public final class Vet extends JsonJpaEntity<Vet> {
     Vet() {
         super();
         this.name = "";
+        this.retired = false;
         this.allSkill = new TreeSet<>();
         this.allSpecies = new TreeSet<>();
     }
@@ -56,6 +62,7 @@ public final class Vet extends JsonJpaEntity<Vet> {
     Vet(@NonNull final Long version, @NonNull final UUID id) {
         super(version, id);
         this.name = "";
+        this.retired = false;
         this.allSkill = new TreeSet<>();
         this.allSpecies = new TreeSet<>();
     }
@@ -73,8 +80,9 @@ public final class Vet extends JsonJpaEntity<Vet> {
         if (that == null) {
             return false;
         }
-        return this.name.equals(that.name)&&
-                this.allSkill.equals(that.allSkill)&&
+        return this.name.equals(that.name) &&
+                this.retired == that.retired &&
+                this.allSkill.equals(that.allSkill) &&
                 this.allSpecies.equals(that.allSpecies);
     }
 
@@ -85,6 +93,7 @@ public final class Vet extends JsonJpaEntity<Vet> {
         }
         final var value = new Vet(getVersion(), id);
         value.name = this.name;
+        value.retired = this.retired;
         value.allSkill = this.allSkill;
         value.allSpecies = this.allSpecies;
         return value;

--- a/lib/backend-api/src/main/java/esy/api/clinic/Visit.adoc
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Visit.adoc
@@ -3,6 +3,5 @@ The treatment `date` is required.
 The treatment `time` is optional because it only becomes definitive once treatment begins.
 The treatment `duration` is required and only becomes definitive at the end of the treatment.
 The diagnosis `text` is required and only becomes definitive at the end of the treatment.
-The `billable` flag indicates whether the visit is subject to billing and defaults to `false`.
 The `pet` relation is optional because visits can be created as placeholders for veterinarians on duty.
 The `vet` relation is optional because the veterinarian on duty is not always known at the time the visit is created.

--- a/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
@@ -144,6 +144,15 @@ public final class Visit extends JsonJpaEntity<Visit> {
     }
 
     @Override
+    public Visit verify() {
+        super.verify();
+        if (this.vet != null && this.vet.isRetired()) {
+            throw new IllegalArgumentException("vet retired");
+        }
+        return this;
+    }
+
+    @Override
     protected void extraJson(@NonNull final Map<String, Object> allExtra) {
         allExtra.put("ownerItem", OwnerItem.fromValue(pet));
         allExtra.put("petItem", PetItem.fromValue(pet));

--- a/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
+++ b/lib/backend-api/src/main/java/esy/api/clinic/Visit.java
@@ -70,11 +70,6 @@ public final class Visit extends JsonJpaEntity<Visit> {
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private Vet vet;
 
-    @Column(name = "billable")
-    @Getter
-    @JsonProperty
-    private boolean billable;
-
     @Column(name = "duration")
     @Getter
     @JsonProperty
@@ -90,7 +85,6 @@ public final class Visit extends JsonJpaEntity<Visit> {
         this.text = "";
         this.pet = null;
         this.vet = null;
-        this.billable = false;
         this.duration = Duration.ZERO;
     }
 
@@ -101,7 +95,6 @@ public final class Visit extends JsonJpaEntity<Visit> {
         this.text = "";
         this.pet = null;
         this.vet = null;
-        this.billable = false;
         this.duration = Duration.ZERO;
     }
 
@@ -123,7 +116,6 @@ public final class Visit extends JsonJpaEntity<Visit> {
                 Objects.equals(this.text, that.text) &&
                 Objects.equals(this.pet, that.pet) &&
                 Objects.equals(this.vet, that.vet) &&
-                this.billable == that.billable &&
                 Objects.equals(this.duration, that.duration);
     }
 
@@ -138,7 +130,6 @@ public final class Visit extends JsonJpaEntity<Visit> {
         value.text = this.text;
         value.pet = this.pet;
         value.vet = this.vet;
-        value.billable = this.billable;
         value.duration = this.duration;
         return value;
     }

--- a/lib/backend-api/src/test/java/esy/api/clinic/VetTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/VetTest.java
@@ -17,6 +17,7 @@ class VetTest {
 		return Vet.fromJson("""
                 {
                 	"name":"%s",
+	                "retired":false,
                 	"allSkill":["Z","A"],
                 	"allSpecies":["Dog","Cat"]
                 }
@@ -61,6 +62,7 @@ class VetTest {
 		assertFalse(json.at("/version").isMissingNode());
 		assertFalse(json.at("/id").isMissingNode());
 		assertFalse(json.at("/name").isMissingNode());
+		assertFalse(json.at("/retired").isMissingNode());
 		assertFalse(json.at("/allSkill").isMissingNode());
 		assertFalse(json.at("/allSpecies").isMissingNode());
 	}
@@ -71,6 +73,7 @@ class VetTest {
 		final var value0 = createWithName(name);
 		assertNotNull(value0.getId());
 		assertNotNull(value0.getName());
+		assertFalse(value0.isRetired());
 		assertNotNull(value0.getAllSkill());
 		assertNotNull(value0.getAllSpecies());
 		final var value1 = value0.withId(value0.getId());
@@ -90,6 +93,19 @@ class VetTest {
                         """.formatted(name));
 		assertDoesNotThrow(value::verify);
 		assertEquals(name, value.getName());
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void jsonRetired(final boolean retired) {
+		final var value = Vet.fromJson("""
+                        {
+                            "name":"Mia Musterfrau",
+                            "retired":"%b"
+                        }
+                        """.formatted(retired));
+		assertDoesNotThrow(value::verify);
+		assertEquals(retired, value.isRetired());
 	}
 
 	@ParameterizedTest

--- a/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
@@ -127,6 +127,23 @@ class VisitTest {
         assertEquals(text, value.getText());
     }
 
+    @Test
+    void jsonVetRetiredConstraints() {
+        final var value = Visit.fromJson("""
+                        {
+                            "date":"2021-04-22",
+                            "text":"Lorem Ipsum."
+                        }
+                        """)
+                .setVet(Vet.fromJson("""
+                        {
+                            "name":"Dr. Retired",
+                            "retired":true
+                        }
+                        """));
+        assertThrows(IllegalArgumentException.class, value::verify);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans =  {true, false})
     void jsonBillable(final boolean billable) {

--- a/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
+++ b/lib/backend-api/src/test/java/esy/api/clinic/VisitTest.java
@@ -92,7 +92,6 @@ class VisitTest {
         assertFalse(json.at("/text").isMissingNode());
         assertFalse(json.at("/date").isMissingNode());
         assertFalse(json.at("/time").isMissingNode());
-        assertFalse(json.at("/billable").isMissingNode());
         assertFalse(json.at("/duration").isMissingNode());
     }
 
@@ -103,7 +102,6 @@ class VisitTest {
         assertNotNull(value0.getId());
         assertNotNull(value0.getDate());
         assertNotNull(value0.getTime());
-        assertFalse(value0.isBillable());
         assertNotNull(value0.getDuration());
         assertNotNull(value0.getPet());
         assertNotNull(value0.getVet());
@@ -142,36 +140,6 @@ class VisitTest {
                         }
                         """));
         assertThrows(IllegalArgumentException.class, value::verify);
-    }
-
-    @ParameterizedTest
-    @ValueSource(booleans =  {true, false})
-    void jsonBillable(final boolean billable) {
-        final var value = Visit.fromJson("""
-                        {
-                            "date":"2021-04-22",
-                            "text":"Lorem Ipsum.",
-                            "billable":"%b"
-                        }
-                        """.formatted(billable));
-        assertDoesNotThrow(value::verify);
-        assertEquals(billable, value.isBillable());
-    }
-
-    @ParameterizedTest
-    @ValueSource(strings = {
-            "JA",
-            "NEIN",
-    })
-    void jsonBillableConstraints(final String text) {
-        final var json = """
-                        {
-                            "date":"2021-04-22",
-                            "text":"Lorem Ipsum.",
-                            "billable":"%s"
-                        }
-                        """.formatted(text);
-        assertThrows(IllegalArgumentException.class, () -> Visit.fromJson(json).verify());
     }
 
     static Stream<LocalDate> jsonDate() {

--- a/lib/backend-data/src/main/resources/graphql/Vet.gqls
+++ b/lib/backend-data/src/main/resources/graphql/Vet.gqls
@@ -1,6 +1,7 @@
 type Vet {
     id: ID!
     name: String!
+    retired: Boolean!
     allSkill: [String]
     allSpecies: [String]
 }

--- a/lib/backend-data/src/main/resources/graphql/Visit.gqls
+++ b/lib/backend-data/src/main/resources/graphql/Visit.gqls
@@ -3,7 +3,6 @@ type Visit {
     date: LocalDate!
     time: LocalTime
     text: String
-    billable: Boolean!
     duration: String!
     pet: Pet
     vet: Vet

--- a/lib/backend-data/src/main/resources/liquibase/v1/vet.xml
+++ b/lib/backend-data/src/main/resources/liquibase/v1/vet.xml
@@ -24,4 +24,11 @@
                 columnNames="name"
         />
     </changeSet>
+    <changeSet id="2" author="robert">
+        <addColumn tableName="vet">
+            <column name="retired" type="BOOLEAN" defaultValueBoolean="false">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/lib/backend-data/src/main/resources/liquibase/v1/visit.xml
+++ b/lib/backend-data/src/main/resources/liquibase/v1/visit.xml
@@ -68,4 +68,7 @@
             </column>
         </addColumn>
     </changeSet>
+    <changeSet id="5" author="robert">
+        <dropColumn tableName="visit" columnName="billable"/>
+    </changeSet>
 </databaseChangeLog>

--- a/lib/backend-data/src/test/java/esy/app/clinic/VetGraphqlTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VetGraphqlTest.java
@@ -32,9 +32,10 @@ class VetGraphqlTest {
     static Vet createWithName(final String name) {
         return Vet.fromJson("""
                 {
-                	"name":"%s",
-                	"allSkill":["Z","A"],
-                	"allSpecies":["Dog","Cat"]
+		        "name":"%s",
+		        "retired":false,
+		        "allSkill":["Z","A"],
+		        "allSpecies":["Dog","Cat"]
                 }
                 """.formatted(name));
     }
@@ -46,7 +47,7 @@ class VetGraphqlTest {
                 .thenReturn(List.of(value));
         final var data = graphQlTester
                 .document("""
-                        {allVet{name allSkill allSpecies}}
+                        {allVet{name retired allSkill allSpecies}}
                         """)
                 .execute();
         assertNotNull(data);
@@ -54,6 +55,10 @@ class VetGraphqlTest {
                 .hasValue()
                 .entity(String.class)
                 .isEqualTo(value.getName());
+        data.path("allVet[0].retired")
+                .hasValue()
+                .entity(Boolean.class)
+                .isEqualTo(value.isRetired());
         data.path("allVet[0].allSkill")
                 .hasValue()
                 .entityList(String.class)

--- a/lib/backend-data/src/test/java/esy/app/clinic/VetRepositoryTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VetRepositoryTest.java
@@ -27,6 +27,7 @@ public class VetRepositoryTest {
         return Vet.fromJson("""
                 {
                 	"name":"%s",
+                    "retired":false,
                 	"allSkill":["Z","A"],
                 	"allSpecies":["Dog","Cat"]
                 }
@@ -44,6 +45,7 @@ public class VetRepositoryTest {
         assertEquals(0L, value0.getVersion());
         assertNotNull(value0.getId());
         assertEquals(name, value0.getName());
+        assertFalse(value0.isRetired());
         assertEquals(2, value0.getAllSkill().size());
         assertEquals("A", value0.getAllSkill().first());
         assertEquals("Z", value0.getAllSkill().last());

--- a/lib/backend-data/src/test/java/esy/app/clinic/VetRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VetRestApiTest.java
@@ -99,6 +99,8 @@ class VetRestApiTest {
                         .isNotEmpty())
                 .andExpect(jsonPath("$.name")
                         .value(name))
+                .andExpect(jsonPath("$.retired")
+                        .value(false))
                 .andExpect(jsonPath("$.allSkill")
                         .isArray())
                 .andExpect(jsonPath("$.allSkill[0]")
@@ -154,6 +156,8 @@ class VetRestApiTest {
                         .value(uuid.toString()))
                 .andExpect(jsonPath("$.name")
                         .value(name))
+                .andExpect(jsonPath("$.retired")
+                        .value(false))
                 .andExpect(jsonPath("$.allSkill")
                         .isArray())
                 .andExpect(jsonPath("$.allSkill[0]")
@@ -193,7 +197,9 @@ class VetRestApiTest {
                 .andExpect(jsonPath("$.id")
                         .value(uuid.toString()))
                 .andExpect(jsonPath("$.name")
-                        .value(name));
+                        .value(name))
+                .andExpect(jsonPath("$.retired")
+                        .value(false));
     }
 
     @Test
@@ -262,6 +268,34 @@ class VetRestApiTest {
                         .value("Dog"))
                 .andExpect(jsonPath("$.allSpecies[2]")
                         .doesNotExist());
+    }
+
+    @Test
+    @Order(403)
+    void patchApiVetRetired() throws Exception {
+        final var uuid = UUID.fromString("a1111111-1111-beef-dead-beefdeadbeef");
+        assertTrue(vetRepository.findById(uuid).isPresent());
+        mockMvc.perform(patch("/api/vet/" + uuid)
+                        .content("""
+                                {
+                                    "retired":true
+                                }
+                                """)
+                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status()
+                        .isOk())
+                .andExpect(content()
+                        .contentType("application/json"))
+                .andExpect(header()
+                        .exists("Vary"))
+                .andExpect(header()
+                        .exists("ETag"))
+                .andExpect(jsonPath("$.id")
+                        .value(uuid.toString()))
+                .andExpect(jsonPath("$.retired")
+                        .value(true));
     }
 
     @Test
@@ -354,11 +388,13 @@ class VetRestApiTest {
                 .andExpect(header()
                         .exists("Vary"))
                 .andExpect(header()
-                        .string("ETag", "\"4\""))
+                        .string("ETag", "\"5\""))
                 .andExpect(jsonPath("$.id")
                         .value(uuid.toString()))
                 .andExpect(jsonPath("$.name")
                         .value(name))
+                .andExpect(jsonPath("$.retired")
+                        .value(true))
                 .andExpect(jsonPath("$.allSkill[0]")
                         .value("A"))
                 .andExpect(jsonPath("$.allSkill[1]")

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitGraphqlTest.java
@@ -77,17 +77,13 @@ class VisitGraphqlTest {
         when(visitRepository.findAll())
                 .thenReturn(List.of(value));
         final var data = graphQlTester
-                .document("{allVisit{text billable duration}}")
+                .document("{allVisit{text duration}}")
                 .execute();
         assertNotNull(data);
         data.path("allVisit[0].text")
                 .hasValue()
                 .entity(String.class)
                 .isEqualTo(value.getText());
-        data.path("allVisit[0].billable")
-                .hasValue()
-                .entity(Boolean.class)
-                .isEqualTo(value.isBillable());
         data.path("allVisit[0].duration")
                 .hasValue()
                 .entity(String.class)

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitRepositoryTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitRepositoryTest.java
@@ -90,7 +90,6 @@ public class VisitRepositoryTest {
         assertEquals(text, value0.getText());
         assertNotNull(value0.getDate());
         assertNotNull(value0.getTime());
-        assertFalse(value0.isBillable());
         assertNotNull(value0.getDuration());
         assertNull(value0.getPet());
         assertNull(value0.getVet());

--- a/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
+++ b/lib/backend-data/src/test/java/esy/app/clinic/VisitRestApiTest.java
@@ -124,9 +124,7 @@ class VisitRestApiTest {
                 .andExpect(jsonPath("$.date")
                         .value(date))
                 .andExpect(jsonPath("$.text")
-                        .exists())
-                .andExpect(jsonPath("$.billable")
-                        .value(false));
+                        .exists());
     }
 
     @Test
@@ -188,9 +186,7 @@ class VisitRestApiTest {
                 .andExpect(jsonPath("$.date")
                         .value(date))
                 .andExpect(jsonPath("$.text")
-                        .value(text))
-                .andExpect(jsonPath("$.billable")
-                        .value(false));
+                        .value(text));
     }
 
     @Test
@@ -382,34 +378,6 @@ class VisitRestApiTest {
 
     @Test
     @Order(407)
-    void patchApiVisitBillable() throws Exception {
-        final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
-        assertTrue(visitRepository.findById(uuid).isPresent());
-        mockMvc.perform(patch("/api/visit/" + uuid)
-                        .content("""
-                                {
-                                    "billable":true
-                                }
-                                """)
-                        .contentType(MediaType.parseMediaType("application/merge-patch+json"))
-                        .accept(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status()
-                        .isOk())
-                .andExpect(content()
-                        .contentType("application/json"))
-                .andExpect(header()
-                        .exists("Vary"))
-                .andExpect(header()
-                        .string("ETag", "\"6\""))
-                .andExpect(jsonPath("$.id")
-                        .value(uuid.toString()))
-                .andExpect(jsonPath("$.billable")
-                        .value(true));
-    }
-
-    @Test
-    @Order(408)
     void patchApiVisitDuration() throws Exception {
         final var uuid = UUID.fromString("e1111111-1111-beef-dead-beefdeadbeef");
         assertTrue(visitRepository.findById(uuid).isPresent());
@@ -429,7 +397,7 @@ class VisitRestApiTest {
                 .andExpect(header()
                         .exists("Vary"))
                 .andExpect(header()
-                        .string("ETag", "\"7\""))
+                        .string("ETag", "\"6\""))
                 .andExpect(jsonPath("$.id")
                         .value(uuid.toString()))
                 .andExpect(jsonPath("$.duration")
@@ -479,7 +447,7 @@ class VisitRestApiTest {
                 .andExpect(header()
                         .exists("Vary"))
                 .andExpect(header()
-                        .string("ETag", "\"7\""))
+                        .string("ETag", "\"6\""))
                 .andExpect(jsonPath("$.id")
                         .value(value.getId().toString()))
                 .andExpect(jsonPath("$.date")
@@ -488,8 +456,6 @@ class VisitRestApiTest {
                         .value(Visit.TIME_FORMATTER.format(value.getTime())))
                 .andExpect(jsonPath("$.text")
                         .value(value.getText()))
-                .andExpect(jsonPath("$.billable")
-                        .value(true))
                 .andExpect(jsonPath("$.duration")
                         .value(value.getDuration().toString()));
     }

--- a/lib/backend-data/src/test/resources/sql/vet.sql
+++ b/lib/backend-data/src/test/resources/sql/vet.sql
@@ -1,6 +1,6 @@
-INSERT INTO vet (id, name)
-    VALUES ('d1111111-1111-beef-dead-beefdeadbeef', 'Alex Fleming');
-INSERT INTO vet (id, name)
-    VALUES ('d2222222-2222-beef-dead-beefdeadbeef', 'Phillip Dick');
-INSERT INTO vet (id, name)
-    VALUES ('d3333333-3333-beef-dead-beefdeadbeef', 'Mark Allen');
+INSERT INTO vet (id, name, retired)
+    VALUES ('d1111111-1111-beef-dead-beefdeadbeef', 'Alex Fleming', false);
+INSERT INTO vet (id, name, retired)
+    VALUES ('d2222222-2222-beef-dead-beefdeadbeef', 'Phillip Dick', false);
+INSERT INTO vet (id, name, retired)
+    VALUES ('d3333333-3333-beef-dead-beefdeadbeef', 'Mark Allen', true);


### PR DESCRIPTION
Add property retired of type boolean to entity Vet. Retired vets are no longer active and cannot not be assigned to visits.

Remove property billable of type boolean from entity Visit.

Update REST API documentation.

Update GraphQL API documentation.
